### PR TITLE
Add Italian, French, and Spanish translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ## Available Languages
 
 - **English** (Current)
-- [Español](/languages/es/README.md) (Coming Soon)
-- [Français](/languages/fr/README.md) (Coming Soon)
+- [Español](/languages/es/README.md)
+- [Français](/languages/fr/README.md)
+- [Italiano](/languages/it/README.md)
 - [Български](/languages/bg/README.md) (Translated by AcTePuKc)
 
 *Want to contribute a translation? See the [Translation Guide](#translation-guide) below.*

--- a/languages/es/README.md
+++ b/languages/es/README.md
@@ -1,31 +1,144 @@
-# Guía Universal para Entrenamiento de Modelos TTS y Preparación de Conjuntos de Datos
+# Guía Universal de Entrenamiento de Modelos TTS y Preparación de Datasets
 
 ## Idiomas Disponibles
 
 - [English](../../README.md) (Original)
 - **Español** (Actual)
-- [Français](../fr/README.md) (Próximamente)
-- [Български](/languages/bg/README.md) (Translated by AcTePuKc)
+- [Français](../fr/README.md)
+- [Italiano](../it/README.md)
+- [Български](../bg/README.md)
 
-*¿Quieres contribuir con una traducción? Consulta la [Guía de Traducción](../../README.md#translation-guide).*
+*¿Quieres contribuir con una traducción? Consulta la [Guía de Traducción](../../README.md#translation-guide) más abajo.*
 
 ## Introducción
 
-¡Bienvenido! Esta guía completa proporciona un proceso universal para preparar tus propios conjuntos de datos de voz y entrenar un modelo personalizado de Text-to-Speech (TTS). Ya sea que tengas un conjunto de datos pequeño (por ejemplo, 10 horas) o uno más grande (más de 100 horas), estos pasos te ayudarán a organizar tus datos correctamente y navegar por el proceso de entrenamiento para la mayoría de los frameworks modernos de TTS.
+¡Bienvenido! Esta guía completa ofrece un proceso universal para preparar tus propios datasets de voz y entrenar un modelo de Texto a Voz (TTS) personalizado. Tanto si tienes un dataset pequeño (por ejemplo, 10 horas) como uno más grande (más de 100 horas), estos pasos te ayudarán a organizar tus datos correctamente y a recorrer el proceso de entrenamiento para la mayoría de los frameworks modernos de TTS.
 
-**Objetivo:** Capacitarte para ajustar o entrenar un modelo TTS en una voz o idioma específico utilizando tus propios pares de audio-texto.
+**Objetivo:** Capacitarte para hacer fine-tuning o entrenar un modelo TTS con una voz o un idioma específicos usando tus propios pares de audio y texto.
 
-**Lo que cubre esta guía:**
-Esta guía se divide en varias partes, cubriendo todo el flujo de trabajo desde la planificación hasta el uso de tu modelo entrenado:
+**Qué Cubre Esta Guía:**
+Esta guía está dividida en varias partes, que cubren todo el flujo de trabajo desde la planificación hasta el uso de tu modelo entrenado:
 
 1.  **Planificación:** Consideraciones iniciales antes de comenzar tu proyecto.
-2.  **Preparación de Datos:** Adquisición, procesamiento y estructuración de datos de audio y texto.
-3.  **Configuración de Entrenamiento:** Preparación de tu entorno y configuración de los parámetros de entrenamiento.
-4.  **Entrenamiento del Modelo:** Lanzamiento, monitoreo y ajuste fino del modelo TTS.
+2.  **Preparación de Datos:** Adquisición, procesamiento y estructuración de los datos de audio y texto.
+3.  **Configuración del Entrenamiento:** Preparación de tu entorno y configuración de los parámetros de entrenamiento.
+4.  **Entrenamiento del Modelo:** Lanzamiento, monitorización y fine-tuning del modelo TTS.
 5.  **Inferencia:** Uso de tu modelo entrenado para sintetizar voz.
-6.  **Empaquetado y Compartición:** Organización y documentación de tu modelo para uso futuro o distribución.
-7.  **Solución de Problemas y Recursos:** Problemas comunes y herramientas útiles.
+6.  **Empaquetado y Compartición:** Organización y documentación de tu modelo para uso o distribución futuros.
+7.  **Resolución de Problemas y Recursos:** Problemas comunes y herramientas útiles.
 
 ---
 
-*Nota: Esta es una traducción en progreso. Las secciones restantes se traducirán próximamente.*
+## 0. Antes de Empezar: Planificando tu Dataset
+
+Antes de recopilar datos, considera estos puntos cruciales para asegurarte de que tu proyecto esté bien definido y sea factible:
+
+1.  **Locutor:** ¿Será un único locutor o varios locutores? Los datasets de un solo locutor son más sencillos para empezar con el fine-tuning o el entrenamiento inicial. Los modelos multi-locutor requieren un cuidadoso equilibrio de datos y gestión de los identificadores de locutor (speaker ID).
+2.  **Fuente de Datos:** ¿De dónde obtendrás el audio? (Audiolibros, podcasts, archivos de radio, datos de voz grabados profesionalmente, tus propias grabaciones). **De forma crucial, asegúrate de tener los derechos o licencias necesarios para usar los datos en el entrenamiento de modelos.**
+3.  **Calidad del Audio:** Busca la mayor calidad posible. Prioriza grabaciones limpias con un mínimo de ruido de fondo, reverberación, música o voces superpuestas. La consistencia en las condiciones de grabación es muy beneficiosa.
+4.  **Idioma y Dominio:** ¿Qué idioma(s) hablará el modelo? ¿Cuál es el estilo de habla o el dominio (por ejemplo, narración, conversacional, lectura de noticias)? El modelo rendirá mejor con texto similar al de sus datos de entrenamiento.
+5.  **Cantidad de Datos Objetivo:** ¿Cuántos datos planeas recopilar o usar?
+    *   **~1-5 horas:** Puede ser suficiente para una *clonación* de voz básica si se usa un modelo preentrenado potente, pero la calidad podría ser limitada.
+    *   **~5-20 horas:** Generalmente considerado el mínimo para un *fine-tuning* decente de una voz específica sobre un modelo preentrenado.
+    *   **50-100+ horas:** Mejor para entrenar modelos robustos o entrenar modelos con menor dependencia de pesos preentrenados, especialmente para idiomas menos comunes.
+    *   **1000+ horas:** Necesario para entrenar modelos de alta calidad y propósito general, en gran medida desde cero.
+6.  **Sampling Rate (frecuencia de muestreo):** Decide un sampling rate objetivo (por ejemplo, 16000 Hz, 22050 Hz, 44100 Hz, 48000 Hz) desde el principio. Las frecuencias más altas capturan más detalle, pero requieren más almacenamiento y cómputo. **Todos tus datos de entrenamiento DEBEN usar de forma consistente la frecuencia elegida.** 22050 Hz es un equilibrio común para muchos modelos TTS.
+
+---
+
+## Resumen del Proceso y Navegación
+
+Esta guía está dividida en módulos enfocados. Sigue los enlaces de abajo para ver los pasos detallados de cada fase:
+
+1.  **➡️ [Preparación de Datos](./guides/1_DATA_PREPARATION.md)**
+    *   Cubre la adquisición, limpieza, segmentación y normalización del audio, la transcripción del texto y la creación de los archivos manifest necesarios para el entrenamiento. Incluye la crucial checklist de calidad de los datos.
+
+2.  **➡️ [Configuración del Entrenamiento](./guides/2_TRAINING_SETUP.md)**
+    *   Te guía a través de la configuración de tu entorno de Python, la instalación de dependencias (como PyTorch con CUDA), la elección de un framework de TTS y la configuración de los parámetros de entrenamiento en tu archivo de configuración.
+
+3.  **➡️ [Entrenamiento del Modelo](./guides/3_MODEL_TRAINING.md)**
+    *   Explica cómo lanzar el script de entrenamiento, monitorizar su progreso (loss, validación), reanudar un entrenamiento interrumpido, y ofrece consejos específicos para el fine-tuning de modelos existentes.
+
+4.  **➡️ [Inferencia](./guides/4_INFERENCE.md)**
+    *   Detalla cómo usar el checkpoint de tu modelo entrenado para sintetizar voz a partir de texto nuevo, incluyendo frases individuales, procesamiento por lotes y consideraciones multi-locutor.
+
+5.  **➡️ [Empaquetado y Compartición](./guides/5_PACKAGING_AND_SHARING.md)**
+    *   Ofrece buenas prácticas para organizar los archivos de tu modelo entrenado (checkpoints, configuraciones, muestras), documentarlos con un README, gestionar versiones y prepararlos para compartir o archivar.
+
+6.  **➡️ [Resolución de Problemas y Recursos](./guides/6_TROUBLESHOOTING_AND_RESOURCES.md)** 
+    *   Ofrece soluciones para problemas comunes que surgen durante el entrenamiento y la inferencia, y enumera herramientas, librerías y comunidades externas útiles.
+
+---
+
+## Conclusión
+
+Siguiendo estas guías, obtendrás una comprensión completa del flujo de trabajo para preparar datos y entrenar tus propios modelos de Texto a Voz. Recuerda que una preparación de datos meticulosa es la base de una voz de alta calidad, y que el proceso de entrenamiento a menudo implica un refinamiento iterativo.
+
+Ahora, dirígete a la sección correspondiente según en qué punto del ciclo de vida de tu proyecto te encuentres. ¡Mucha suerte construyendo tus voces personalizadas! 🚀
+
+## Contribuir 
+
+¡Las contribuciones para mejorar esta guía son bienvenidas! Ya sea que encuentres erratas, imprecisiones, tengas sugerencias para explicaciones más claras, quieras añadir información sobre herramientas o frameworks específicos, o tengas ideas para nuevas secciones, tu aporte es valioso.
+
+No dudes en:
+
+*   **Abrir un Issue:** Para reportar errores, sugerir mejoras o discutir posibles cambios.
+*   **Enviar un Pull Request:** Para correcciones o adiciones concretas. Por favor, intenta asegurarte de que tus cambios sean claros y estén alineados con la estructura y el tono general de la guía.
+
+¡Agradecemos cualquier esfuerzo por hacer esta guía más precisa, completa y útil para la comunidad!
+
+## Glosario de Términos Técnicos
+
+Este glosario explica los términos técnicos clave usados a lo largo de las guías para ayudar a los recién llegados a entender la terminología:
+
+- **ASR (Automatic Speech Recognition)**: Tecnología que convierte el lenguaje hablado en texto escrito; se utiliza para transcribir datos de audio (Reconocimiento Automático del Habla).
+- **Batch Size**: El número de ejemplos de entrenamiento que se procesan juntos en un mismo paso hacia adelante/atrás (forward/backward); afecta a la velocidad de entrenamiento y al uso de memoria (tamaño de lote).
+- **Checkpoint**: Una instantánea guardada de los pesos de un modelo durante o después del entrenamiento, que permite reanudar el entrenamiento o usar el modelo para inferencia.
+- **CUDA**: La plataforma de computación paralela de NVIDIA que permite la aceleración por GPU para tareas de deep learning.
+- **dBFS (Decibels relative to Full Scale)**: Una unidad de medida para los niveles de audio en sistemas digitales, donde 0 dBFS representa el nivel máximo posible (decibelios relativos a la escala completa).
+- **Diffusion Models**: Una clase de modelos generativos que gradualmente añaden y luego eliminan ruido de los datos; algunos sistemas TTS recientes usan este enfoque (modelos de difusión).
+- **FFT (Fast Fourier Transform)**: Un algoritmo que convierte señales del dominio del tiempo a representaciones del dominio de la frecuencia; fundamental para el procesamiento de audio (Transformada Rápida de Fourier).
+- **Fine-tuning**: El proceso de tomar un modelo preentrenado y seguir entrenándolo con un dataset más pequeño y específico para adaptarlo a una nueva voz o idioma (ajuste fino).
+- **LUFS (Loudness Units relative to Full Scale)**: Una medida estandarizada de la sonoridad percibida, más representativa de la audición humana que las mediciones de pico.
+- **Manifest File**: Un archivo de texto que enumera los archivos de audio y sus transcripciones correspondientes, usado para indicarle al script de entrenamiento dónde encontrar los datos (archivo manifest).
+- **Mel Spectrogram**: Una representación visual del audio que aproxima la percepción auditiva humana usando la escala mel; comúnmente usado como representación intermedia en sistemas TTS (espectrograma mel).
+- **Overfitting**: Cuando un modelo aprende demasiado bien los datos de entrenamiento, incluyendo su ruido y valores atípicos, lo que resulta en un mal rendimiento con datos nuevos (sobreajuste).
+- **Sampling Rate**: El número de muestras de audio por segundo (medido en Hz); las frecuencias más altas capturan más detalle del audio pero requieren más almacenamiento y potencia de procesamiento (frecuencia de muestreo).
+- **STFT (Short-Time Fourier Transform)**: Una técnica que determina el contenido de frecuencia de secciones locales de una señal a medida que cambia en el tiempo (Transformada de Fourier de Tiempo Corto).
+- **TTS (Text-to-Speech)**: Tecnología que convierte texto escrito en salida de voz hablada (Texto a Voz).
+- **Validation Loss**: Una métrica que mide el error de un modelo sobre un dataset de validación (datos no usados para el entrenamiento); ayuda a detectar el overfitting (pérdida de validación).
+- **VRAM (Video RAM)**: Memoria de una tarjeta gráfica; los modelos de deep learning y sus cálculos intermedios se almacenan aquí durante el entrenamiento.
+- **Vocoder**: Un componente de algunos sistemas TTS que convierte características acústicas (como los espectrogramas mel) en formas de onda (audio real).
+
+## Guía de Traducción
+
+Damos la bienvenida a las traducciones de esta guía para hacerla accesible a una audiencia más amplia. Si deseas contribuir con una traducción, sigue estos pasos:
+
+1. **Haz un fork del repositorio** a tu propia cuenta de GitHub
+2. **Crea la estructura de directorios necesaria** para tu idioma:
+   ```
+   languages/[language_code]/
+   ├── README.md
+   └── guides/
+       ├── 1_DATA_PREPARATION.md
+       ├── 2_TRAINING_SETUP.md
+       └── ... (todos los archivos de la guía)
+   ```
+   Donde `[language_code]` es el código de dos letras ISO 639-1 de tu idioma (por ejemplo, `es` para español)
+
+3. **Traduce el contenido** comenzando por el README.md y luego los archivos individuales de la guía
+   - Mantén la misma estructura de archivos y el mismo formato Markdown
+   - Mantén todos los ejemplos de código sin cambios (deben permanecer en inglés)
+   - Traduce todo el texto explicativo, los encabezados y los comentarios
+
+4. **Actualiza los enlaces de navegación** para que apunten a los archivos correctos dentro del directorio de tu idioma
+
+5. **Envía un Pull Request** con tu traducción
+
+**Notas Importantes para los Traductores:**
+- Los términos técnicos pueden ser difíciles de traducir. En caso de duda, puedes mantener el término en inglés seguido de una breve explicación en tu idioma.
+- Intenta mantener el mismo tono y nivel de detalle técnico que el original.
+- Si encuentras errores o áreas de mejora en el contenido original en inglés mientras traduces, por favor abre un issue separado para abordarlos.
+
+## [Licencia](../../LICENCE.md)
+El contenido de esta guía está licenciado bajo la [Licencia Internacional Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/). Eres libre de compartir y adaptar el material siempre que proporciones la atribución adecuada. El contenido también está protegido bajo el copyright de 2025 AcTePuKc y cualquier nueva contribución estará sujeta a la misma licencia.

--- a/languages/es/guides/1_DATA_PREPARATION.md
+++ b/languages/es/guides/1_DATA_PREPARATION.md
@@ -1,0 +1,573 @@
+# Guía 1: Preparación de Datos para el Entrenamiento de TTS
+
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Siguiente Paso: Configuración del Entrenamiento](./2_TRAINING_SETUP.md){: .btn .btn-primary} | 
+
+Esta guía cubre la primera fase crítica de cualquier proyecto de TTS: preparar datos de audio y texto de alta calidad y con el formato correcto. La calidad de tu dataset impacta directamente en la calidad de tu modelo TTS final.
+
+---
+
+## 1. Pasos de Preparación del Dataset
+
+Sigue estos pasos de forma sistemática para transformar el audio en bruto en un dataset listo para entrenar.
+
+### 1.1. Adquisición de Audio y Procesamiento Inicial
+
+-   **Reunir Audio:** Recopila tus archivos de audio en bruto (los formatos comunes incluyen WAV, MP3, FLAC, OGG, M4A). Asegúrate de tener los derechos para usar este audio.
+-   **Convertir a WAV:** La mayoría de los frameworks de TTS esperan el formato WAV. Usa herramientas como `ffmpeg` o librerías de audio (`pydub`, `soundfile`) para convertir tu audio. Apunta a una codificación WAV estándar como PCM de 16 bits.
+    ```bash
+    # Ejemplo usando ffmpeg para convertir MP3 a WAV
+    ffmpeg -i input_audio.mp3 output_audio.wav
+    ```
+-   **Estandarizar Canales (Mono):** Los modelos TTS normalmente se entrenan con audio de un solo canal (mono). Convierte las pistas estéreo a mono.
+    ```bash
+    # Ejemplo usando ffmpeg para convertir WAV estéreo a WAV mono
+    ffmpeg -i stereo_input.wav -ac 1 mono_output.wav
+    ```
+    *   `-ac 1`: Establece el número de canales de audio en 1.
+-   **Remuestrear Audio:** Asegúrate de que todos los archivos de audio tengan **exactamente el mismo sampling rate**. Elige tu frecuencia objetivo según los objetivos de tu proyecto y la compatibilidad con el framework (por ejemplo, 16000 Hz, 22050 Hz, 48000 Hz). 22050 Hz es común para muchos modelos.
+    ```bash
+    # Ejemplo usando ffmpeg para remuestrear a 22050 Hz
+    ffmpeg -i input.wav -ar 22050 resampled_output.wav
+    ```
+    *   `-ar 22050`: Establece el sampling rate del audio (muestras por segundo).
+
+### 1.2 Limpieza Avanzada del Audio (Eliminación de Ruido/Música) - *Opcional pero Recomendado*
+
+-   **Objetivo:** Eliminar sonidos de fondo no deseados como ruido (zumbidos, siseos, ventiladores), música, reverberación u otras voces que interfieran de tu audio fuente, aislando la voz del locutor objetivo en la medida de lo posible. Este paso es crucial si tu audio fuente no tiene calidad de estudio.
+-   **¿Por qué?** Los modelos TTS aprenden del audio que se les proporciona. Si el audio contiene ruido de fondo o música, es probable que la voz TTS resultante herede estas características, sonando ruidosa o "turbia". Un audio más limpio conduce a una voz TTS más limpia.
+
+-   **Herramientas y Técnicas:**
+    *   **Herramientas de Separación de Fuentes por IA (Recomendadas para Música/Voz):** Estas herramientas usan modelos de IA para separar el audio en diferentes pistas (stems) (voces, música, batería, bajo, otros).
+        *   **[Ultimate Vocal Remover (UVR)](https://ultimatevocalremover.com/)**: Una aplicación con interfaz gráfica (GUI) popular, gratuita y de código abierto que proporciona acceso a varios modelos de separación por IA de última generación. Es excelente para eliminar música de fondo o aislar diálogos.
+            *   **Modelos (como los mencionados):** UVR te permite usar diferentes modelos de IA. `MDX-Inst-HQ3` es uno de esos modelos, a menudo bueno para separar voces de instrumentos (de ahí "Inst"). Otros modelos MDX, los modelos Demucs (como `htdemucs`) y, potencialmente, modelos como Mel-Roformer (si está integrado o disponible de forma independiente) están diseñados para tareas similares, cada uno con fortalezas y debilidades ligeramente diferentes. La experimentación es clave. Elige modelos enfocados en el **aislamiento de voz**.
+        *   **Otras Herramientas:** Los servicios en línea (por ejemplo, Lalal.ai) u otro software independiente podrían usar modelos subyacentes similares (a menudo variantes de Demucs o Spleeter).
+    *   **Herramientas Tradicionales de Reducción de Ruido:** A menudo se encuentran en estaciones de trabajo de audio digital (DAWs) o editores de audio.
+        *   **[Audacity](https://www.audacityteam.org/):** Contiene efectos integrados de reducción de ruido (requiere muestrear un perfil de ruido). Puede ser eficaz para el ruido de fondo constante (como siseos o zumbidos).
+        *   **Plugins Comerciales (por ejemplo, Izotope RX, Waves Clarity):** Ofrecen herramientas de aislamiento de voz, ruido y reverberación más sofisticadas y basadas en IA, pero tienen un coste.
+    *   **Edición Espectral:** Eliminar manualmente sonidos no deseados en un editor espectral (como Adobe Audition, Izotope RX, Acon Digital Acoustica). Potente, pero muy laborioso.
+
+-   **Consideraciones sobre el Flujo de Trabajo:**
+    *   **Cuándo Aplicarlo:** Generalmente se recomienda aplicar la limpieza a tus **archivos de audio más largos *antes* de la segmentación (Paso 1.3 a continuación)**. Esto permite que los modelos de IA trabajen con más contexto y puede ser más eficiente que procesar miles de segmentos pequeños. Sin embargo, si la limpieza introduce demasiados artefactos en los archivos largos, podrías intentar limpiar individualmente los segmentos problemáticos más adelante.
+    *   **Proceso:**
+        1.  Carga tu archivo WAV estandarizado (del Paso 1.1) en la herramienta elegida (por ejemplo, UVR).
+        2.  Selecciona un modelo de aislamiento de voz apropiado (por ejemplo, un modelo de voz MDX o Demucs).
+        3.  Procesa el audio para generar una pista de "solo voces".
+        4.  **Escucha con Atención:** Evalúa críticamente la pista de voz separada. Comprueba si hay:
+            *   **Artefactos:** La separación por IA a veces puede introducir sonidos "acuosos", fallos (glitches), o partes de la voz que se eliminan por error.
+            *   **Ruido/Música Restantes:** ¿Con qué eficacia se eliminó el sonido no deseado?
+        5.  **Itera:** Es posible que necesites probar diferentes modelos, ajustar la configuración dentro de la herramienta, o incluso aplicar una segunda pasada de reducción de ruido (por ejemplo, usando la reducción de ruido de Audacity sobre las voces separadas por IA) para obtener los mejores resultados.
+    *   **Guardar la Salida:** Guarda la pista de voz limpia como un nuevo archivo WAV (por ejemplo, `original_file_cleaned.wav`). Usa estos archivos limpios como entrada para el *siguiente* paso (Segmentación).
+
+-   **Advertencias:**
+    *   **Los Artefactos son Posibles:** Una limpieza agresiva puede degradar la naturalidad de la voz objetivo. Busca un equilibrio entre eliminar el ruido y preservar la calidad de la voz.
+    *   **Coste Computacional:** Los modelos de separación por IA pueden ser computacionalmente intensivos y pueden requerir un tiempo significativo, especialmente en archivos de audio largos y sin una GPU potente.
+
+
+### 1.3. Segmentación del Audio (División en Segmentos)
+
+-   **Objetivo:** Dividir archivos de audio largos (como capítulos de un audiolibro o episodios de podcast) en segmentos más cortos y manejables. La duración ideal de un segmento suele estar entre **2 y 15 segundos**.
+-   **¿Por qué Segmentar?**
+    *   Alinea la duración del audio con las longitudes típicas de las frases.
+    *   Hace factible la transcripción (transcribir archivos de horas de duración es difícil).
+    *   Ayuda a gestionar la memoria durante el entrenamiento.
+    *   Permite filtrar segmentos no aptos (por ejemplo, silencio puro, ruido, música).
+-   **Método:** Usa herramientas que detecten el silencio para dividir el audio. `pydub` es una librería de Python popular para esto.
+
+    ```python
+    # Ejemplo usando pydub para la división basada en silencio
+    from pydub import AudioSegment
+    from pydub.silence import split_on_silence
+    import os
+
+    input_file = "resampled_mono_audio.wav" # Usa la salida del paso 1.1
+    output_dir = "audio_chunks"             # Crea este directorio
+    os.makedirs(output_dir, exist_ok=True)
+
+    print(f"Loading audio file: {input_file}")
+    sound = AudioSegment.from_wav(input_file)
+    print("Audio loaded. Splitting based on silence...")
+
+    chunks = split_on_silence(
+        sound,
+        min_silence_len=500,    # Duración mínima del silencio en milisegundos para activar una división. Ajusta según sea necesario.
+        silence_thresh=-40,     # Umbral de silencio en dBFS (decibelios relativos a la escala completa). Valores más bajos (p. ej., -50) detectan silencios más tenues. Ajusta según el nivel de ruido de fondo de tu audio.
+        keep_silence=200        # Opcional: cantidad de silencio (en ms) a dejar al inicio/final de cada segmento. Ayuda a evitar cortes bruscos.
+    )
+
+    print(f"Found {len(chunks)} potential chunks before duration filtering.")
+
+    # --- Filtrado y Exportación ---
+    min_duration_sec = 2.0  # Duración mínima del segmento en segundos
+    max_duration_sec = 15.0 # Duración máxima del segmento en segundos
+    target_sr = 22050       # Asegura que los segmentos conserven el sampling rate correcto (pydub suele encargarse de esto)
+
+    exported_count = 0
+    for i, chunk in enumerate(chunks):
+        duration_sec = len(chunk) / 1000.0
+        if min_duration_sec <= duration_sec <= max_duration_sec:
+            # Asegura que el segmento use el sampling rate objetivo si es necesario (pydub intenta preservarlo)
+            # chunk = chunk.set_frame_rate(target_sr) # Normalmente no es necesario si la fuente se muestreó correctamente
+            
+            chunk_filename = f"segment_{exported_count:05d}.wav" # Usa relleno (padding) para facilitar la ordenación
+            chunk_path = os.path.join(output_dir, chunk_filename)
+            
+            print(f"Exporting chunk {i} ({duration_sec:.2f}s) to {chunk_path}")
+            chunk.export(chunk_path, format="wav")
+            exported_count += 1
+        else:
+             print(f"Skipping chunk {i} due to duration: {duration_sec:.2f}s")
+
+
+    print(f"\nExported {exported_count} chunks meeting duration criteria ({min_duration_sec}-{max_duration_sec}s) to '{output_dir}'.")
+    ```
+-   **Revisión:** Escucha una muestra de los segmentos generados. ¿Son lógicas las divisiones? ¿Se corta el habla? Ajusta `min_silence_len` y `silence_thresh` y vuelve a ejecutar si es necesario. Para audio complicado podría ser necesario dividir o refinar las divisiones manualmente en un editor de audio (como Audacity).
+
+### 1.4. Normalización de Volumen
+
+-   **Objetivo:** Asegurar que todos los segmentos de audio tengan un nivel de volumen consistente. Esto evita que los segmentos silenciosos o ruidosos afecten de forma desproporcionada al entrenamiento.
+-   **Métodos:**
+    *   **Normalización de Pico (Peak Normalization):** Ajusta el audio para que el punto más alto alcance un nivel específico (por ejemplo, -3.0 dBFS). Simple, pero no garantiza una sonoridad *percibida* consistente.
+    *   **Normalización de Sonoridad (LUFS):** Ajusta el audio para alcanzar un nivel de sonoridad percibida objetivo (por ejemplo, -23 LUFS es común para radiodifusión). Generalmente preferida, ya que refleja mejor la audición humana. Requiere librerías como `pyloudnorm`.
+-   **Aplicar de Forma Consistente:** Aplica el método de normalización elegido a *todos* los segmentos creados en el paso anterior. Guarda los archivos normalizados en un **nuevo directorio** (por ejemplo, `normalized_chunks`) para mantener los originales intactos.
+
+    ```python
+    # Ejemplo usando pydub para la normalización de PICO (PEAK)
+    from pydub import AudioSegment
+    import os
+    import glob
+
+    input_chunk_dir = "audio_chunks"
+    output_norm_dir = "normalized_chunks"
+    os.makedirs(output_norm_dir, exist_ok=True)
+    
+    target_dBFS = -3.0 # Amplitud de pico objetivo
+
+    def match_target_amplitude(sound, target_dBFS):
+        change_in_dBFS = target_dBFS - sound.dBFS
+        return sound.apply_gain(change_in_dBFS)
+
+    print(f"Normalizing chunks from '{input_chunk_dir}' to '{output_norm_dir}' with target peak {target_dBFS} dBFS.")
+    
+    wav_files = glob.glob(os.path.join(input_chunk_dir, "*.wav"))
+    
+    for i, wav_file in enumerate(wav_files):
+        filename = os.path.basename(wav_file)
+        output_path = os.path.join(output_norm_dir, filename)
+        
+        try:
+            sound = AudioSegment.from_wav(wav_file)
+            # Aplica ganancia solo si el sonido no es silencio (dBFS no es -inf)
+            if sound.dBFS > -float('inf'):
+              normalized_sound = match_target_amplitude(sound, target_dBFS)
+              normalized_sound.export(output_path, format="wav")
+            else:
+              print(f"Skipping silent file: {filename}")
+              # Opcionalmente copia los archivos silenciosos o gestiónalos según sea necesario
+              # shutil.copy(wav_file, output_path) 
+            
+            if (i + 1) % 50 == 0: # Imprime el progreso
+                 print(f"Processed {i+1}/{len(wav_files)} files...")
+                 
+        except Exception as e:
+            print(f"Error processing {filename}: {e}")
+
+    print(f"\nNormalization complete. Normalized files saved in '{output_norm_dir}'.")
+    ```
+    *   **Nota:** Para la normalización LUFS, usarías una librería como `pyloudnorm`, iterando por los archivos de forma similar.
+
+### 1.5. Transcripción: Creación de Pares de Texto
+
+-   **Objetivo:** Obtener una transcripción de texto precisa para *cada uno de los segmentos de audio normalizados*. El texto debe representar *exactamente* lo que se dice en el audio.
+-   **Métodos:**
+    *   **Reconocimiento Automático del Habla (ASR):** Lo mejor para datasets grandes. Usa modelos ASR de alta calidad.
+    *   **[OpenAI Whisper](https://github.com/openai/whisper):** Una excelente opción multilingüe y de código abierto. Se ejecuta localmente (se recomienda GPU) o a través de API. *Nota: Aunque es potente para la precisión de las palabras, la puntuación y el uso de mayúsculas de Whisper pueden requerir una revisión y corrección cuidadosas durante el paso de limpieza.* Varios modelos de Whisper con fine-tuning de la comunidad (a menudo encontrados en Hugging Face) pueden ofrecer mejoras.
+    *   **[Modelos Google Gemini](https://ai.google.dev/) (por ejemplo, vía API o AI Studio):** Modelos como Gemini Pro o Flash pueden realizar la transcripción de audio. A menudo requieren que el audio esté en formatos específicos y pueden rendir mejor en segmentos más cortos (alineándose bien con el paso previo de segmentación). Comprueba las ofertas actuales de la API y los posibles niveles gratuitos.
+    *   **Servicios en la Nube:** Google Cloud Speech-to-Text, AWS Transcribe, Azure Speech Service ofrecen APIs robustas, a menudo con precios de pago por uso y posibles niveles gratuitos iniciales.
+    *   **Otros Modelos:** Explora [Hugging Face Models](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition) para encontrar otros modelos ASR de código abierto o con fine-tuning específicos para tu idioma.
+    *   **Transcripción Manual:** La más precisa, pero muy laboriosa. Adecuada para datasets pequeños y de alto valor o para *corregir las salidas de ASR*.
+    *   **Transcripciones Existentes:** Si tu audio fuente viene con transcripciones alineadas (por ejemplo, algunos audiolibros, archivos de radiodifusión), es posible que necesites scripts para analizarlas y alinearlas con tus segmentos.
+-   **Formato de Salida:** Crea un archivo `.txt` por cada archivo `.wav` correspondiente en tu directorio `normalized_chunks`. Los nombres de los archivos deben coincidir exactamente (por ejemplo, `normalized_chunks/segment_00001.wav` necesita `transcripts/segment_00001.txt`).
+-   **Limpieza y Normalización del Texto:** **¡Esto es crucial!**
+    *   **Eliminar Elementos que no son Habla:** Elimina marcas de tiempo (como `[00:01:05]`), etiquetas de locutor ("SPEAKER A:", "John Doe:"), etiquetas de eventos sonoros (`[laughter]`, `[music]`), comentarios de transcripción.
+    *   **Gestionar Muletillas (Filler Words):** Decide si conservar o eliminar las muletillas comunes ("uh", "um", "ah"). Conservarlas puede hacer que el TTS suene más natural, pero también puede introducir vacilaciones no deseadas. Eliminarlas conduce a un habla más limpia y directa. La consistencia es clave.
+    *   **Puntuación:** Asegura una puntuación consistente y apropiada. Las comas, puntos y signos de interrogación ayudan al modelo a aprender la prosodia. Evita la puntuación excesiva o no estándar.
+    *   **Números, Acrónimos, Símbolos:** Expándelos a palabras (por ejemplo, "101" -> "ciento uno", "EE. UU." -> "E E U U" o "Estados Unidos de América", "%" -> "por ciento"). La forma de expandirlos depende de cómo quieras que el TTS los pronuncie. Crea un diccionario/conjunto de reglas de normalización si es necesario.
+    *   **Mayúsculas/Minúsculas:** Normalmente convierte el texto a un formato consistente (por ejemplo, minúsculas), a menos que tu framework/tokenizador de TTS gestione las mayúsculas adecuadamente. Consulta la documentación del framework.
+    *   **Caracteres Especiales:** Elimina o reemplaza los caracteres que podrían confundir al tokenizador (por ejemplo, emojis, caracteres de control).
+
+    ```
+    # Ejemplo de estructura:
+    my_tts_dataset/
+    ├── normalized_chunks/
+    │   ├── segment_00001.wav
+    │   ├── segment_00002.wav
+    │   └── ...
+    └── transcripts/
+        ├── segment_00001.txt  # Contiene "Hola mundo."
+        ├── segment_00002.txt  # Contiene "Esta es una frase de prueba."
+        └── ...
+    ```
+
+### 1.6. Estructuración de los Datos y Creación del Archivo Manifest
+
+-   **Objetivo:** Crear archivos de índice (manifests) que le indiquen al script de entrenamiento de TTS dónde encontrar los archivos de audio y sus transcripciones correspondientes.
+-   **Formato del Manifest:** El formato más común es un archivo de texto plano donde cada línea representa un par de audio-texto, separados por un delimitador (normalmente una barra vertical `|`).
+    ```
+    path/to/audio_chunk.wav|El texto de transcripción correspondiente|speaker_id
+    ```
+    *   `path/to/audio_chunk.wav`: Ruta relativa al archivo de audio normalizado desde el directorio donde se ejecutará el script de entrenamiento.
+    *   `El texto de transcripción correspondiente`: El texto limpio y normalizado del archivo `.txt`.
+    *   `speaker_id`: Un identificador para el locutor (por ejemplo, `speaker0`, `mary_smith`). Para datasets de un solo locutor, usa el mismo ID para todas las líneas. Para datasets multi-locutor, usa IDs únicos para cada locutor distinto.
+-   **División de los Datos (Entrenamiento/Validación):** Divide tus datos en un conjunto de entrenamiento (usado para actualizar los pesos del modelo) y un conjunto de validación (usado para monitorizar el rendimiento sobre datos no vistos y prevenir el overfitting). Una división común es del 90-98% para entrenamiento y del 2-10% para validación. **De forma crucial, asegúrate de que los segmentos de una *misma grabación larga original* no acaben en ambos conjuntos (entrenamiento y validación) si es posible, para evitar fugas de datos (data leakage).** Si divides de forma aleatoria, mezcla (shuffle) primero.
+-   **Script para Generar Manifests:**
+
+    ```python
+    import os
+    import random
+
+    # --- Configuración ---
+    dataset_name = "my_tts_dataset"
+    normalized_audio_dir = os.path.join(dataset_name, "normalized_chunks")
+    transcripts_dir = os.path.join(dataset_name, "transcripts")
+    output_dir = dataset_name # Donde se guardarán los archivos manifest
+
+    train_manifest_path = os.path.join(output_dir, "train_list.txt")
+    val_manifest_path = os.path.join(output_dir, "val_list.txt")
+
+    speaker_id = "main_speaker" # Usa un ID consistente para datasets de un solo locutor
+                                # Para multi-locutor, determina el ID según el nombre de archivo o la fuente
+    val_split_ratio = 0.05    # 5% para el conjunto de validación
+    random_seed = 42          # Para divisiones reproducibles
+    # ---------------------
+
+    manifest_entries = []
+    print("Reading audio and transcript files...")
+
+    # Itera por los archivos de audio normalizados
+    wav_files = sorted([f for f in os.listdir(normalized_audio_dir) if f.endswith(".wav")])
+
+    for wav_filename in wav_files:
+        base_filename = os.path.splitext(wav_filename)[0]
+        txt_filename = base_filename + ".txt"
+        
+        audio_path = os.path.join(normalized_audio_dir, wav_filename)
+        # Usa os.path.relpath si tu script de entrenamiento se ejecuta desde una raíz diferente
+        # relative_audio_path = os.path.relpath(audio_path, start=training_script_dir) 
+        relative_audio_path = audio_path # Asumiendo que el script se ejecuta desde la raíz que contiene 'my_tts_dataset'
+
+        transcript_path = os.path.join(transcripts_dir, txt_filename)
+
+        if os.path.exists(transcript_path):
+            try:
+                with open(transcript_path, "r", encoding="utf-8") as f:
+                    transcript = f.read().strip()
+                
+                # Limpieza básica: elimina caracteres de barra vertical, recorta espacios sobrantes
+                transcript = transcript.replace('|', ' ').strip()
+                transcript = ' '.join(transcript.split()) # Normaliza los espacios en blanco
+
+                if transcript: # Asegura que la transcripción no esté vacía tras la limpieza
+                    manifest_entries.append(f"{relative_audio_path}|{transcript}|{speaker_id}")
+                else:
+                    print(f"Warning: Empty transcript for {wav_filename}. Skipping.")
+            except Exception as e:
+                print(f"Error reading or processing transcript {txt_filename}: {e}. Skipping.")
+        else:
+            print(f"Warning: Missing transcript file {txt_filename} for {wav_filename}. Skipping.")
+
+    print(f"Found {len(manifest_entries)} valid audio-transcript pairs.")
+
+    # Mezcla y divide
+    random.seed(random_seed)
+    random.shuffle(manifest_entries)
+
+    split_idx = int(len(manifest_entries) * (1 - val_split_ratio))
+    train_entries = manifest_entries[:split_idx]
+    val_entries = manifest_entries[split_idx:]
+
+    # Escribe los archivos manifest
+    try:
+        with open(train_manifest_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(train_entries))
+        print(f"Successfully wrote {len(train_entries)} entries to {train_manifest_path}")
+
+        with open(val_manifest_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(val_entries))
+        print(f"Successfully wrote {len(val_entries)} entries to {val_manifest_path}")
+    except Exception as e:
+        print(f"Error writing manifest files: {e}")
+
+    ```
+
+---
+
+## 2. Checklist de Calidad de los Datos
+
+Antes de pasar a la configuración del entrenamiento, revisa rigurosamente tu dataset preparado usando esta checklist. Solucionar los problemas ahora ahorra mucho tiempo después.
+
+| Aspecto                  | Comprobación                                                               | ¿Por qué es Importante?                                             | Acción si Falla                                                                      |
+| :---------------------- | :-------------------------------------------------------------------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| **Completitud del Audio**  | ¿Existen realmente todos los archivos `.wav` listados en los manifests?               | El entrenamiento se bloqueará si faltan archivos.                | Vuelve a ejecutar la generación de manifests; comprueba las rutas de los archivos; asegúrate de que ningún archivo se haya borrado por accidente. |
+| **Coincidencia de Transcripción**    | ¿Tiene cada `.wav` un `.txt`/transcripción correspondiente y preciso?    | Los pares mal emparejados enseñan al modelo asociaciones incorrectas. | Verifica los nombres de archivo; revisa la salida del ASR; corrige las transcripciones manualmente.                     |
+| **Duración del Audio**        | ¿Está la mayoría de los segmentos dentro del rango deseado (p. ej., 2-15s)? ¿Pocos valores atípicos? | Los segmentos muy cortos/largos pueden desestabilizar el entrenamiento.       | Vuelve a ejecutar la segmentación con parámetros ajustados; filtra manualmente los valores atípicos de los manifests.      |
+| **Calidad del Audio**       | Escucha muestras aleatorias: ¿Poco ruido de fondo? ¿Sin música/reverberación/eco? | Basura entra, basura sale. El modelo aprende el ruido.         | Mejora el audio fuente; aplica reducción de ruido (¡con cuidado!); filtra los segmentos malos.     |
+| **Consistencia del Locutor** | Para un solo locutor: ¿Es siempre la voz objetivo? ¿Sin otros locutores? | Previene la dilución o inestabilidad de la voz.                    | Revisa/filtra los segmentos manualmente; comprueba los límites de la segmentación.                         |
+| **Formato y Especificaciones** | ¿Todo WAV? ¿Sampling rate **idéntico**? ¿Canales mono? ¿PCM de 16 bits?      | Las inconsistencias causan errores o un rendimiento pobre. | Vuelve a ejecutar los pasos de conversión/remuestreo (Sección 1.1). Verifica las especificaciones por lotes usando herramientas de línea de comandos como `ffprobe` o `soxi` (parte del paquete [SoX](http://sox.sourceforge.net/)). Ejemplo: `soxi -r *.wav` para comprobar las frecuencias. |
+| **Niveles de Volumen**       | Escucha muestras aleatorias: ¿Son los volúmenes relativamente consistentes?          | Los cambios drásticos de volumen pueden dificultar el aprendizaje.               | Vuelve a ejecutar la normalización (Sección 1.3); comprueba los parámetros de normalización.                 |
+| **Limpieza de la Transcripción** | ¿Sin marcas de tiempo, etiquetas de locutor? ¿Muletillas gestionadas de forma consistente? ¿Puntuación estándar? ¿Números/símbolos expandidos? | Asegura que el texto se mapee limpiamente a los sonidos del habla/prosodia.      | Vuelve a ejecutar los scripts de limpieza de texto; realiza una revisión y corrección manuales.                   |
+| **Formato del Manifest**     | ¿Estructura `path|text|speaker_id` correcta? ¿Rutas válidas? ¿Sin líneas extra? | Los errores del parser impedirán la carga de los datos.                 | Comprueba el delimitador (`|`); valida las rutas relativas a la ubicación del script de entrenamiento; comprueba la codificación (se prefiere UTF-8). |
+| **División Entrenamiento/Validación**     | ¿Son los archivos de validación realmente no vistos durante el entrenamiento? ¿Sin solapamiento?        | Los datos solapados dan puntuaciones de validación engañosas.     | Asegura una mezcla (shuffle) aleatoria antes de dividir; comprueba la lógica de división.                        |
+
+**Consejo:** Usa herramientas como `soxi` (de SoX) o `ffprobe` para comprobar por lotes las propiedades del audio (sampling rate, canales, duración). Escribe pequeños scripts para verificar la existencia de los archivos y el formato básico del manifest.
+
+### 2.1. Scripts Prácticos de Verificación
+
+Aquí tienes algunos scripts prácticos para ayudarte a verificar la calidad de tu dataset:
+
+#### Comprobar las Propiedades del Audio (Sampling Rate, Canales, Duración)
+
+```bash
+#!/bin/bash
+# verify_audio.sh - Comprueba las propiedades del audio en todos los archivos WAV
+# Uso: ./verify_audio.sh /path/to/audio/directory
+
+AUDIO_DIR="$1"
+echo "Checking audio files in $AUDIO_DIR..."
+
+# Comprueba si SoX está instalado
+if ! command -v soxi &> /dev/null; then
+    echo "SoX not found. Please install it first (e.g., 'apt-get install sox' or 'brew install sox')."
+    exit 1
+fi
+
+# Inicializa contadores y arrays
+total_files=0
+non_mono=0
+wrong_rate=0
+too_short=0
+too_long=0
+target_rate=22050  # Cambia esto por tu sampling rate objetivo
+min_duration=1.0   # Duración mínima en segundos
+max_duration=15.0  # Duración máxima en segundos
+
+# Procesa todos los archivos WAV
+find "$AUDIO_DIR" -name "*.wav" | while read -r file; do
+    total_files=$((total_files + 1))
+    
+    # Obtiene las propiedades del audio
+    channels=$(soxi -c "$file")
+    rate=$(soxi -r "$file")
+    duration=$(soxi -d "$file" | awk -F: '{ print ($1 * 3600) + ($2 * 60) + $3 }')
+    
+    # Comprueba las propiedades
+    if [ "$channels" -ne 1 ]; then
+        echo "WARNING: Non-mono file: $file (channels: $channels)"
+        non_mono=$((non_mono + 1))
+    fi
+    
+    if [ "$rate" -ne "$target_rate" ]; then
+        echo "WARNING: Wrong sampling rate: $file (rate: $rate Hz, expected: $target_rate Hz)"
+        wrong_rate=$((wrong_rate + 1))
+    fi
+    
+    if (( $(echo "$duration < $min_duration" | bc -l) )); then
+        echo "WARNING: File too short: $file (duration: ${duration}s, minimum: ${min_duration}s)"
+        too_short=$((too_short + 1))
+    fi
+    
+    if (( $(echo "$duration > $max_duration" | bc -l) )); then
+        echo "WARNING: File too long: $file (duration: ${duration}s, maximum: ${max_duration}s)"
+        too_long=$((too_long + 1))
+    fi
+    
+    # Imprime el progreso cada 100 archivos
+    if [ $((total_files % 100)) -eq 0 ]; then
+        echo "Processed $total_files files..."
+    fi
+done
+
+# Imprime el resumen
+echo "===== SUMMARY ====="
+echo "Total files checked: $total_files"
+echo "Non-mono files: $non_mono"
+echo "Files with wrong sampling rate: $wrong_rate"
+echo "Files too short (<${min_duration}s): $too_short"
+echo "Files too long (>${max_duration}s): $too_long"
+
+if [ $((non_mono + wrong_rate + too_short + too_long)) -eq 0 ]; then
+    echo "All files passed basic checks!"
+else
+    echo "Some issues were found. Please review the warnings above."
+fi
+```
+
+#### Verificar la Integridad del Archivo Manifest
+
+```python
+#!/usr/bin/env python3
+# verify_manifest.py - Comprueba que todos los archivos del manifest existen y tienen transcripciones coincidentes
+# Uso: python verify_manifest.py path/to/manifest.txt
+
+import os
+import sys
+from pathlib import Path
+
+def verify_manifest(manifest_path):
+    """Verifica que todos los archivos de audio y transcripciones del manifest existen y son válidos."""
+    if not os.path.exists(manifest_path):
+        print(f"Error: Manifest file '{manifest_path}' not found.")
+        return False
+    
+    print(f"Verifying manifest: {manifest_path}")
+    base_dir = os.path.dirname(os.path.abspath(manifest_path))
+    
+    # Estadísticas
+    total_entries = 0
+    missing_audio = 0
+    empty_transcripts = 0
+    
+    with open(manifest_path, 'r', encoding='utf-8') as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            
+            total_entries += 1
+            
+            # Analiza la línea (asumiendo formato separado por barra vertical: audio_path|transcript|speaker_id)
+            parts = line.split('|')
+            if len(parts) < 2:
+                print(f"Line {line_num}: Invalid format. Expected at least 'audio_path|transcript'")
+                continue
+            
+            audio_path = parts[0]
+            transcript = parts[1]
+            
+            # Comprueba si la ruta del audio es relativa y resuélvela
+            if not os.path.isabs(audio_path):
+                audio_path = os.path.join(base_dir, audio_path)
+            
+            # Comprueba si el archivo de audio existe
+            if not os.path.exists(audio_path):
+                print(f"Line {line_num}: Audio file not found: {audio_path}")
+                missing_audio += 1
+            
+            # Comprueba si la transcripción está vacía
+            if not transcript or transcript.isspace():
+                print(f"Line {line_num}: Empty transcript for {audio_path}")
+                empty_transcripts += 1
+    
+    # Imprime el resumen
+    print("\n===== SUMMARY =====")
+    print(f"Total entries: {total_entries}")
+    print(f"Missing audio files: {missing_audio}")
+    print(f"Empty transcripts: {empty_transcripts}")
+    
+    if missing_audio == 0 and empty_transcripts == 0:
+        print("All manifest entries are valid!")
+        return True
+    else:
+        print("Issues found in manifest. Please fix them before proceeding.")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python verify_manifest.py path/to/manifest.txt")
+        sys.exit(1)
+    
+    success = verify_manifest(sys.argv[1])
+    sys.exit(0 if success else 1)
+```
+
+#### Visualizar Espectrogramas de Audio para Evaluar la Calidad
+
+Este script te ayuda a inspeccionar visualmente la calidad de tus archivos de audio generando espectrogramas:
+
+```python
+#!/usr/bin/env python3
+# generate_spectrograms.py - Crea espectrogramas para evaluar la calidad del audio
+# Uso: python generate_spectrograms.py /path/to/audio/directory /path/to/output/directory [num_samples]
+
+import os
+import sys
+import random
+import numpy as np
+import matplotlib.pyplot as plt
+import librosa
+import librosa.display
+from pathlib import Path
+
+def generate_spectrograms(audio_dir, output_dir, num_samples=10):
+    """Genera espectrogramas para una muestra aleatoria de archivos de audio."""
+    # Crea el directorio de salida si no existe
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Obtiene todos los archivos WAV
+    wav_files = list(Path(audio_dir).glob('**/*.wav'))
+    if not wav_files:
+        print(f"No WAV files found in {audio_dir}")
+        return False
+    
+    # Toma una muestra de los archivos si hay más de los solicitados
+    if len(wav_files) > num_samples:
+        wav_files = random.sample(wav_files, num_samples)
+    
+    print(f"Generating spectrograms for {len(wav_files)} files...")
+    
+    for i, wav_path in enumerate(wav_files):
+        try:
+            # Carga el archivo de audio
+            y, sr = librosa.load(wav_path, sr=None)
+            
+            # Crea la figura con dos subgráficos
+            plt.figure(figsize=(12, 8))
+            
+            # Dibuja la forma de onda
+            plt.subplot(2, 1, 1)
+            librosa.display.waveshow(y, sr=sr)
+            plt.title(f'Waveform: {wav_path.name}')
+            plt.xlabel('Time (s)')
+            plt.ylabel('Amplitude')
+            
+            # Dibuja el espectrograma
+            plt.subplot(2, 1, 2)
+            D = librosa.amplitude_to_db(np.abs(librosa.stft(y)), ref=np.max)
+            librosa.display.specshow(D, sr=sr, x_axis='time', y_axis='log')
+            plt.colorbar(format='%+2.0f dB')
+            plt.title('Log-frequency power spectrogram')
+            
+            # Guarda la figura
+            output_path = os.path.join(output_dir, f'spectrogram_{i+1}_{wav_path.stem}.png')
+            plt.tight_layout()
+            plt.savefig(output_path)
+            plt.close()
+            
+            print(f"Generated: {output_path}")
+            
+        except Exception as e:
+            print(f"Error processing {wav_path}: {e}")
+    
+    print(f"Spectrograms saved to {output_dir}")
+    return True
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python generate_spectrograms.py /path/to/audio/directory /path/to/output/directory [num_samples]")
+        sys.exit(1)
+    
+    audio_dir = sys.argv[1]
+    output_dir = sys.argv[2]
+    num_samples = int(sys.argv[3]) if len(sys.argv) > 3 else 10
+    
+    success = generate_spectrograms(audio_dir, output_dir, num_samples)
+    sys.exit(0 if success else 1)
+```
+
+Estos scripts proporcionan herramientas prácticas para verificar la calidad de tu dataset antes del entrenamiento, ayudándote a identificar y solucionar problemas en una fase temprana del proceso.
+
+---
+
+Una vez que tu dataset pase esta comprobación de calidad, estarás listo para proceder con la configuración del entorno de entrenamiento.
+
+**Siguiente Paso:** [Configuración del Entrenamiento](./2_TRAINING_SETUP.md){: .btn .btn-primary} |
+[Volver Arriba](#top){: .btn .btn-primary}

--- a/languages/es/guides/2_TRAINING_SETUP.md
+++ b/languages/es/guides/2_TRAINING_SETUP.md
@@ -1,0 +1,253 @@
+# Guía 2: Configuración y Ajuste del Entorno de Entrenamiento
+
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Paso Anterior: Preparación de Datos](./1_DATA_PREPARATION.md){: .btn .btn-primary} | [Siguiente Paso: Entrenamiento del Modelo](./3_MODEL_TRAINING.md){: .btn .btn-primary}
+
+Con tu dataset preparado, la siguiente etapa consiste en configurar el entorno de software necesario y ajustar los parámetros para tu ejecución de entrenamiento específica.
+
+---
+
+## 3. Configuración del Entorno de Entrenamiento
+
+Esta sección cubre la instalación del software requerido y la organización de los archivos de tu proyecto.
+
+### 3.1. Elegir y Clonar un Framework de TTS
+
+-   **Selecciona un Framework:** Elige una base de código de TTS adecuada para tus objetivos. Considera factores como:
+    *   **Arquitectura:** VITS, StyleTTS2, Tacotron2+Vocoder, etc. Las arquitecturas más nuevas a menudo producen mejor calidad.
+    *   **Soporte para Fine-tuning:** ¿El framework soporta explícitamente el fine-tuning a partir de modelos preentrenados? Esto suele ser más fácil que entrenar desde cero.
+    *   **Soporte de Idioma:** Comprueba si el modelo/tokenizador gestiona bien tu idioma objetivo.
+    *   **Comunidad y Mantenimiento:** ¿Se mantiene el repositorio de forma activa? ¿Hay debates de la comunidad o canales de soporte?
+    *   **Modelos Preentrenados:** ¿El framework proporciona modelos preentrenados adecuados como punto de partida para el fine-tuning?
+
+#### Comparación de Arquitecturas de TTS
+
+Al seleccionar una arquitectura de TTS, considera estas opciones populares y sus características:
+
+| Arquitectura | Ventajas | Desventajas | Mejor Para | Requisitos de Hardware |
+|:-------------|:-----|:-----|:---------|:---------------------|
+| **VITS** | • De extremo a extremo (sin vocoder separado)<br>• Audio de alta calidad<br>• Inferencia rápida<br>• Buena para fine-tuning | • Compleja de entender<br>• Puede ser inestable durante el entrenamiento<br>• Requiere un ajuste cuidadoso de hiperparámetros | • Clonación de voz de un solo locutor<br>• Proyectos que necesitan una salida de alta calidad<br>• Cuando tienes más de 5 horas de datos | • Entrenamiento: 8GB+ VRAM<br>• Inferencia: 4GB+ VRAM |
+| **StyleTTS2** | • Excelente control de voz y estilo<br>• Calidad de última generación<br>• Buena para emoción/prosodia | • Más nueva, implementaciones potencialmente menos estables<br>• Arquitectura más compleja<br>• Menos recursos de la comunidad | • Proyectos que requieren control de estilo<br>• Síntesis de habla expresiva<br>• Multi-locutor con transferencia de estilo | • Entrenamiento: 12GB+ VRAM<br>• Inferencia: 6GB+ VRAM |
+| **Tacotron2 + HiFi-GAN** | • Bien establecida, estable<br>• Más fácil de entender<br>• Más tutoriales disponibles<br>• Componentes separados para una depuración más fácil | • Pipeline de dos etapas (más lento)<br>• Generalmente menor calidad que los modelos más nuevos<br>• Más propensa a fallos de atención en textos largos | • Proyectos educativos<br>• Cuando se prioriza la estabilidad sobre la calidad<br>• Entornos de bajos recursos | • Entrenamiento: 6GB+ VRAM<br>• Inferencia: 2GB+ VRAM |
+| **FastSpeech2** | • No autorregresiva (inferencia más rápida)<br>• Más estable que Tacotron2<br>• Buena documentación | • Requiere alineaciones de fonemas<br>• Preprocesamiento más complejo<br>• Calidad no tan alta como VITS/StyleTTS2 | • Aplicaciones en tiempo real<br>• Cuando la velocidad de inferencia es crítica<br>• Salida más controlada | • Entrenamiento: 8GB+ VRAM<br>• Inferencia: 2GB+ VRAM |
+| **YourTTS (variante de VITS)** | • Soporte multilingüe<br>• Clonación de voz zero-shot<br>• Buena para transferencia de idioma | • Configuración de entrenamiento compleja<br>• Requiere una preparación cuidadosa de los datos<br>• Puede necesitar datasets más grandes | • Proyectos multilingües<br>• Clonación de voz interlingüe<br>• Cuando se necesita flexibilidad de idioma | • Entrenamiento: 10GB+ VRAM<br>• Inferencia: 4GB+ VRAM |
+| **TTS basado en Difusión** | • El mayor potencial de calidad<br>• Prosodia más natural<br>• Mejor manejo de palabras raras | • Inferencia muy lenta<br>• Entrenamiento extremadamente intensivo en cómputo<br>• Más nueva, menos establecida | • Generación offline<br>• Cuando la calidad supera a la velocidad<br>• Proyectos de investigación | • Entrenamiento: 16GB+ VRAM<br>• Inferencia: 8GB+ VRAM |
+
+**Nota sobre los Requisitos de Hardware:**
+- Estos son mínimos aproximados; tamaños de batch más grandes o configuraciones de modelo más grandes requerirán más VRAM
+- Los tiempos de entrenamiento varían significativamente: VITS/StyleTTS2 normalmente necesitan más epochs que Tacotron2
+- La inferencia por CPU es posible para todos los modelos, pero será significativamente más lenta
+
+### 1.3. Requisitos de Hardware Detallados
+
+Elegir el hardware adecuado es crítico para un entrenamiento exitoso de modelos TTS. Aquí tienes un desglose detallado de los requisitos para diferentes escenarios:
+
+#### Requisitos de GPU por Tipo de Modelo y Tamaño del Dataset
+
+| Tipo de Modelo | Dataset Pequeño (<10h) | Dataset Mediano (10-50h) | Dataset Grande (>50h) | Modelos de GPU Recomendados |
+|:-----------|:---------------------|:------------------------|:---------------------|:-----------------------|
+| **Tacotron2 + HiFi-GAN** | 8GB VRAM | 12GB VRAM | 16GB+ VRAM | RTX 3060, RTX 2080, T4 |
+| **FastSpeech2** | 8GB VRAM | 12GB VRAM | 16GB+ VRAM | RTX 3060, RTX 2080, T4 |
+| **VITS** | 12GB VRAM | 16GB VRAM | 24GB+ VRAM | RTX 3080, RTX 3090, A5000 |
+| **StyleTTS2** | 16GB VRAM | 24GB VRAM | 32GB+ VRAM | RTX 3090, RTX 4090, A100 |
+| **XTTS-v2** | 24GB VRAM | 32GB VRAM | 40GB+ VRAM | RTX 4090, A100, A6000 |
+| **TTS basado en Difusión** | 16GB VRAM | 24GB VRAM | 32GB+ VRAM | RTX 3090, RTX 4090, A100 |
+
+#### CPU y Memoria del Sistema
+
+| Escala de Entrenamiento | Requisitos de CPU | RAM del Sistema | Almacenamiento |
+|:---------------|:-----------------|:-----------|:--------|
+| **Aficionado/Personal** | 4+ núcleos, 2.5GHz+ | 16GB | 50GB SSD |
+| **Investigación** | 8+ núcleos, 3.0GHz+ | 32GB | 100GB+ SSD |
+| **Producción** | 16+ núcleos, 3.5GHz+ | 64GB+ | 500GB+ NVMe SSD |
+
+#### Opciones de GPU en la Nube y Costes Aproximados
+
+| Proveedor de Nube | Opción de GPU | VRAM | Coste Aprox./Hora | Mejor Para |
+|:---------------|:-----------|:-----|:------------------|:---------|
+| **Google Colab** | T4/P100 (Gratis)<br>V100/A100 (Pro) | 16GB<br>16-40GB | Gratis<br>$10-$15 | Experimentación, datasets pequeños |
+| **Kaggle** | P100/T4 | 16GB | Gratis (horas limitadas) | Datasets pequeños-medianos |
+| **AWS** | g4dn.xlarge (T4)<br>p3.2xlarge (V100)<br>p4d.24xlarge (A100) | 16GB<br>16GB<br>40GB | $0.50-$0.75<br>$3.00-$3.50<br>$20.00-$32.00 | Cualquier escala, producción |
+| **GCP** | n1-standard-8 + T4<br>a2-highgpu-1g (A100) | 16GB<br>40GB | $0.35-$0.50<br>$3.80-$4.50 | Cualquier escala, producción |
+| **Azure** | NC6s_v3 (V100)<br>NC24ads_A100_v4 | 16GB<br>80GB | $3.00-$3.50<br>$16.00-$24.00 | Cualquier escala, producción |
+| **Lambda Labs** | 1x RTX 3090<br>1x A100 | 24GB<br>40GB | $1.10<br>$1.99 | Investigación, datasets medianos |
+| **Vast.ai** | Varias GPUs de consumo | 8-24GB | $0.20-$1.00 | Entrenamiento con presupuesto ajustado |
+
+#### Estimaciones de Tiempo de Entrenamiento
+
+| Modelo | Tamaño del Dataset | GPU | Tiempo de Entrenamiento Aproximado | Epochs hasta Convergencia |
+|:------|:-------------|:----|:--------------------------|:----------------------|
+| **Tacotron2 + HiFi-GAN** | 10 horas | RTX 3080 | 2-3 días | 50-100K pasos |
+| **FastSpeech2** | 10 horas | RTX 3080 | 2-3 días | 150-200K pasos |
+| **VITS** | 10 horas | RTX 3090 | 3-5 días | 300-500K pasos |
+| **StyleTTS2** | 10 horas | RTX 3090 | 4-7 días | 500-800K pasos |
+| **XTTS-v2** | 10 horas | RTX 4090 | 5-10 días | 1M+ pasos |
+
+#### Consejos de Optimización para Reducir los Requisitos de Hardware
+
+1. **Gradient Accumulation (acumulación de gradientes)**: Simula tamaños de batch más grandes acumulando gradientes a lo largo de múltiples pasos hacia adelante/atrás (forward/backward)
+2. **Mixed Precision Training (entrenamiento de precisión mixta)**: Usa FP16 en lugar de FP32 para reducir el uso de VRAM hasta en un 50%
+3. **Gradient Checkpointing**: Intercambia cómputo por memoria recalculando las activaciones durante el paso hacia atrás (backward pass)
+4. **Model Parallelism (paralelismo de modelo)**: Divide modelos grandes entre múltiples GPUs
+5. **Progressive Training (entrenamiento progresivo)**: Empieza con modelos/configuraciones más pequeños y aumenta gradualmente la complejidad
+
+Estos requisitos deberían ayudarte a planificar tus necesidades de hardware según los objetivos específicos de tu proyecto y tus restricciones de presupuesto.
+-   **Clona el Repositorio:** Una vez elegido, clona el repositorio de código del framework usando Git.
+    ```bash
+    git clone <URL_OF_YOUR_CHOSEN_TTS_REPO>
+    cd <TTS_REPO_DIRECTORY> # Navega dentro del directorio clonado
+    ```
+    *   Ejemplo: `git clone https://github.com/some-user/some-tts-framework.git`
+
+### 3.2. Configurar el Entorno de Python e Instalar Dependencias
+
+-   **Entorno Virtual (Recomendado):** Crea y activa un entorno virtual de Python dedicado para aislar las dependencias y evitar conflictos con otros proyectos o con los paquetes de Python del sistema.
+    *   **Usando `venv` (integrado):**
+        ```bash
+        python -m venv venv_tts  # Crea un entorno llamado 'venv_tts'
+        # Actívalo:
+        # Windows: .\venv_tts\Scripts\activate
+        # Linux/macOS: source venv_tts/bin/activate
+        ```
+    *   **Usando `conda`:**
+        ```bash
+        conda create --name tts_env python=3.9 # O la versión de Python deseada
+        conda activate tts_env
+        ```
+-   **Instalar PyTorch con CUDA:** Esto es crítico para la aceleración por GPU. Visita la [Guía Oficial de Instalación de PyTorch](https://pytorch.org/get-started/locally/) y selecciona las opciones que coincidan con tu sistema operativo, gestor de paquetes (`pip` o `conda`), plataforma de cómputo (versión de CUDA) y la versión de PyTorch deseada. **Asegúrate de que los drivers de NVIDIA instalados sean compatibles con la versión de CUDA elegida.**
+    ```bash
+    # Comando de ejemplo usando pip para CUDA 11.8 (¡consulta el sitio web de PyTorch para los comandos actuales!)
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+    # Verifica la instalación:
+    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); print(torch.version.cuda)"
+    # Debería mostrar la versión de PyTorch, True, y tu versión de CUDA si tiene éxito.
+    ```
+-   **Instalar los Requisitos del Framework:** La mayoría de los frameworks listan sus dependencias en un archivo `requirements.txt`. Instálalas usando `pip` (o `uv`, que suele ser más rápido).
+    ```bash
+    # Navega primero al directorio del framework si no estás ya allí
+    # Usando pip:
+    pip install -r requirements.txt
+
+    # Usando uv (si está instalado: pip install uv):
+    uv pip install -r requirements.txt
+    ```
+    *   **Resolución de Problemas:** Presta atención a cualquier error de instalación. Podría indicar la falta de librerías del sistema (como `libsndfile`), versiones de paquetes incompatibles, o problemas con tu configuración de CUDA/PyTorch. Consulta la documentación del framework para conocer los prerrequisitos específicos.
+
+### 3.3. Organizar la Carpeta de tu Proyecto
+
+-   Una estructura de carpetas bien organizada facilita la gestión de tu proyecto. Coloca tu dataset preparado (o crea un enlace simbólico a él) dentro o junto al código del framework. Una estructura común se ve así:
+
+    ```bash
+    <YOUR_PROJECT_ROOT>/
+    ├── <TTS_REPO_DIRECTORY>/         # El código del framework clonado
+    │   ├── train.py                 # Script principal de entrenamiento (el nombre puede variar)
+    │   ├── inference.py             # Script de inferencia (el nombre puede variar)
+    │   ├── configs/                 # Directorio para los archivos de configuración
+    │   │   └── base_config.yaml     # Configuración de ejemplo del framework
+    │   ├── requirements.txt
+    │   └── ... (otros archivos del framework)
+    │
+    ├── my_tts_dataset/              # Tu dataset preparado de la Guía 1
+    │   ├── normalized_chunks/       # Archivos de audio finales
+    │   │   ├── segment_00001.wav
+    │   │   └── ...
+    │   ├── transcripts/             # Opcional: archivos de texto si no están directamente en el manifest
+    │   ├── train_list.txt           # Manifest de entrenamiento
+    │   └── val_list.txt             # Manifest de validación
+    │
+    ├── checkpoints/                 # Crea este directorio: donde se guardarán los modelos
+    │   └── my_custom_model/         # Subdirectorio para una ejecución de entrenamiento específica
+    │
+    └── my_configs/                  # Opcional: coloca aquí tus configuraciones personalizadas
+        └── my_training_run_config.yaml
+    ```
+-   **Rutas:** Asegúrate de que las rutas especificadas más adelante en tu archivo de configuración (para datasets, salidas) sean correctas en relación con el lugar desde donde *ejecutarás* el script `train.py` (normalmente desde dentro del `<TTS_REPO_DIRECTORY>`).
+
+---
+
+## 4. Configurando la Ejecución del Entrenamiento
+
+Antes de lanzar el entrenamiento, necesitas crear un archivo de configuración que le indique al framework *cómo* entrenar el modelo, usando *tus* datos específicos.
+
+### 4.1. Encontrar y Copiar una Configuración Base
+
+-   **Localiza Ejemplos:** Explora el directorio `configs/` dentro del framework de TTS. Busca archivos de configuración (`.yaml`, `.json`, o similares) que sirvan como plantillas.
+-   **Elige Apropiadamente:** Selecciona un archivo de configuración que coincida con tu objetivo:
+    *   **Fine-tuning:** Busca nombres como `config_ft.yaml`, `finetune_*.yaml`. Estos a menudo asumen que proporcionarás un modelo preentrenado.
+    *   **Entrenamiento desde Cero:** Busca nombres como `config_base.yaml`, `train_*.yaml`.
+    *   **Tamaño del Dataset:** Algunos frameworks podrían ofrecer configuraciones ajustadas para datasets pequeños (`_sm`) o grandes (`_lg`).
+-   **Copia y Renombra:** Copia el archivo de plantilla elegido a una nueva ubicación (por ejemplo, tu propio directorio `my_configs/` o dentro del directorio `configs/` del framework) y dale un nombre descriptivo para tu ejecución específica (por ejemplo, `my_yoruba_voice_ft_config.yaml`).
+    ```bash
+    # Ejemplo: copiando una configuración de fine-tuning
+    cp <TTS_REPO_DIRECTORY>/configs/base_finetune_config.yaml my_configs/my_yoruba_voice_ft_config.yaml
+    ```
+
+### 4.2. Editar tu Archivo de Configuración Personalizado
+
+-   Abre tu archivo de configuración recién copiado (`my_yoruba_voice_ft_config.yaml`) en un editor de texto.
+-   **Modifica los Parámetros Clave:** Revisa y modifica cuidadosamente los parámetros. Los nombres de los parámetros **variarán significativamente** entre frameworks, pero las categorías comunes incluyen:
+
+    ```yaml
+    # --- Dataset y Carga de Datos ---
+    # Rutas relativas al lugar desde donde ejecutas train.py
+    train_filelist_path: "../my_tts_dataset/train_list.txt" # Ruta a tu manifest de entrenamiento
+    val_filelist_path: "../my_tts_dataset/val_list.txt"   # Ruta a tu manifest de validación
+    # Algunos frameworks podrían necesitar 'data_path' o 'audio_root' apuntando al directorio de audio en su lugar/adicionalmente.
+
+    # --- Salida y Registro (Logging) ---
+    output_directory: "../checkpoints/my_yoruba_voice_run1" # MUY IMPORTANTE: donde se guardan modelos, logs, muestras. Crea este directorio base si es necesario.
+    log_interval: 100                  # Cada cuánto (en pasos/batches) imprimir logs
+    validation_interval: 1000          # Cada cuánto (en pasos/batches) ejecutar la validación
+    save_checkpoint_interval: 5000     # Cada cuánto (en pasos/batches) guardar los checkpoints del modelo
+
+    # --- Hiperparámetros Centrales del Entrenamiento ---
+    epochs: 1000                       # Número total de pasadas sobre los datos de entrenamiento. Ajusta según el tamaño del dataset y la convergencia.
+    batch_size: 16                     # Número de muestras procesadas en paralelo por GPU. REDUCE si obtienes errores de CUDA OOM. AUMENTA para un entrenamiento más rápido si la VRAM lo permite.
+    learning_rate: 1e-4                # Tasa de aprendizaje inicial. Puede necesitar ajuste (p. ej., más baja para fine-tuning: 5e-5 o 1e-5).
+    # lr_scheduler: "cosine_decay"     # Programación de la tasa de aprendizaje (p. ej., step decay, exponential decay) - depende del framework
+    # weight_decay: 0.01               # Parámetro de regularización
+
+    # --- Parámetros de Audio ---
+    sampling_rate: 22050               # CRÍTICO: DEBE coincidir con el sampling rate de tu dataset preparado (de la Guía 1).
+    # Otros parámetros de audio (a menudo dependen de la arquitectura del modelo):
+    # filter_length: 1024              # Tamaño de FFT para STFT
+    # hop_length: 256                  # Tamaño de salto (hop) para STFT
+    # win_length: 1024                 # Tamaño de la ventana para STFT
+    # n_mel_channels: 80               # Número de bandas Mel
+    # mel_fmin: 0.0                    # Frecuencia Mel mínima
+    # mel_fmax: 8000.0                 # Frecuencia Mel máxima (a menudo sampling_rate / 2)
+
+    # --- Arquitectura del Modelo ---
+    # model_type: "VITS"               # Tipo de arquitectura del modelo
+    # hidden_channels: 192             # Tamaño de las capas internas
+    # num_speakers: 1                  # Establece >1 para datasets multi-locutor (debe coincidir con la preparación de datos)
+
+    # --- Aspectos Específicos del Fine-tuning (Si Aplica) ---
+    # Establece 'True' o proporciona la ruta al hacer fine-tuning
+    fine_tuning: True
+    pretrained_model_path: "/path/to/downloaded/base_model.pth" # Ruta al checkpoint preentrenado del que partir.
+    # Opcional: especifica las capas a ignorar/reinicializar si es necesario
+    # ignore_layers: ["speaker_embedding.weight", "decoder.output_layer.weight"]
+    ```
+-   **Lee la Documentación del Framework:** Consulta la documentación específica de tu framework de TTS elegido para entender qué hace cada parámetro de su archivo de configuración.
+
+### 4.3. Consideraciones de Hardware y Dataset
+
+-   **VRAM de la GPU:** El `batch_size` es el principal control para gestionar el uso de memoria de la GPU. Empieza con un valor recomendado (por ejemplo, 16 o 32) y redúcelo si encuentras errores de "CUDA out of memory" durante el inicio del entrenamiento. Los tamaños de batch más grandes generalmente conducen a una convergencia más rápida, pero requieren más VRAM.
+-   **Tamaño del Dataset vs. Epochs:**
+    *   **Datasets Pequeños (< 20h):** Pueden requerir menos epochs (por ejemplo, 300-1500), pero necesitan una monitorización cuidadosa a través del validation loss/muestras para evitar el overfitting (cuando el modelo memoriza los datos de entrenamiento pero rinde mal con texto nuevo). Considera tasas de aprendizaje más bajas.
+    *   **Datasets Grandes (> 50h):** Pueden beneficiarse de más epochs (1000+) para aprender por completo los patrones de los datos.
+-   **CPU:** Aunque la GPU hace el trabajo pesado, se necesita una CPU multinúcleo decente para la carga y el preprocesamiento de datos, que de lo contrario puede convertirse en un cuello de botella.
+-   **Almacenamiento:** Asegúrate de tener suficiente espacio en disco para el dataset, el entorno de Python, el código del framework y, especialmente, los checkpoints guardados, que pueden llegar a ser grandes (de cientos de MB a GB por checkpoint).
+
+### 4.4. Herramientas de Monitorización (TensorBoard)
+
+-   La mayoría de los frameworks modernos de TTS se integran con [TensorBoard](https://www.tensorflow.org/tensorboard) para visualizar el progreso del entrenamiento.
+-   El archivo de configuración a menudo tiene ajustes relacionados con el registro (logging) (por ejemplo, `use_tensorboard: True`, `log_directory`).
+-   Durante el entrenamiento, normalmente puedes lanzar TensorBoard ejecutando `tensorboard --logdir <YOUR_OUTPUT_DIRECTORY>` (por ejemplo, `tensorboard --logdir ../checkpoints/my_yoruba_voice_run1`) en una terminal separada. Esto te permite monitorizar las curvas de loss, las tasas de aprendizaje y, potencialmente, escuchar muestras de validación sintetizadas en tu navegador web.
+
+---
+
+Con tu entorno configurado y el archivo de configuración adaptado a tus datos y objetivos, ahora estás listo para comenzar el proceso real de entrenamiento del modelo.
+
+**Siguiente Paso:** [Entrenamiento del Modelo](./3_MODEL_TRAINING.md){: .btn .btn-primary} | 
+[Volver Arriba](#top){: .btn .btn-primary}

--- a/languages/es/guides/3_MODEL_TRAINING.md
+++ b/languages/es/guides/3_MODEL_TRAINING.md
@@ -1,0 +1,281 @@
+# Guía 3: Entrenamiento y Fine-tuning del Modelo
+
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Paso Anterior: Configuración del Entrenamiento](./2_TRAINING_SETUP.md){: .btn .btn-primary} | [Siguiente Paso: Inferencia](./4_INFERENCE.md){: .btn .btn-primary}
+
+Has preparado tus datos y configurado tu entorno de entrenamiento. Ahora es el momento de entrenar (o hacer fine-tuning de) tu modelo de Texto a Voz de verdad. Esta fase implica ejecutar el script de entrenamiento, monitorizar su progreso y entender cómo gestionar el proceso.
+
+---
+
+## 5. Ejecutando el Entrenamiento
+
+Esta sección detalla cómo lanzar, monitorizar y gestionar el proceso de entrenamiento.
+
+### 5.1. Lanzando el Script de Entrenamiento
+
+-   **Navega al Directorio Correcto:** Abre tu terminal o línea de comandos y navega al directorio principal del repositorio del framework de TTS clonado (el directorio que contiene el script `train.py` o su equivalente).
+-   **Activa el Entorno Virtual:** Asegúrate de que tu entorno virtual de Python dedicado (por ejemplo, `venv_tts`, `tts_env`) esté activado.
+    ```bash
+    # Activación de ejemplo (ajusta la ruta/nombre según sea necesario)
+    # Windows: ..\venv_tts\Scripts\activate
+    # Linux/macOS: source ../venv_tts/bin/activate
+    # Conda: conda activate tts_env
+    ```
+-   **Ejecuta el Comando de Entrenamiento:** Ejecuta el script de entrenamiento del framework, apuntándolo a tu archivo de configuración personalizado creado en la Guía 2. La estructura exacta del comando varía entre frameworks. Los patrones comunes incluyen:
+    ```bash
+    # Patrón Común 1: usando el argumento --config
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml
+
+    # Patrón Común 2: usando -c para la configuración y -m para el nombre del directorio de modelo/salida
+    # (Comprueba si tu output_directory en la configuración es sobrescrito por -m)
+    python train.py -c ../my_configs/my_yoruba_voice_ft_config.yaml -m my_yoruba_voice_run1
+
+    # Patrón Común 3: especificando directamente el directorio de checkpoints
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --checkpoint_path ../checkpoints/my_yoruba_voice_run1
+    ```
+    *   **Entrenamiento Multi-GPU:** Si tienes múltiples GPUs y el framework soporta entrenamiento distribuido (consulta su documentación), podrías usar comandos que involucren `torchrun` o `python -m torch.distributed.launch`. Ejemplo:
+        ```bash
+        # Ejemplo usando torchrun (ajusta nproc_per_node a tu número de GPUs)
+        torchrun --nproc_per_node=2 train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml
+        ```
+
+### 5.2. Monitorizando el Progreso del Entrenamiento
+
+-   **Salida en Consola:** La terminal donde lanzaste el entrenamiento mostrará información sobre el progreso. Busca:
+    *   **Inicialización:** Mensajes que indican que se está construyendo el modelo, que se preparan los cargadores de datos (data loaders) y, potencialmente, que se está cargando un modelo preentrenado (para fine-tuning).
+    *   **Epochs/Pasos:** El progreso actual del entrenamiento (por ejemplo, `Epoch: [1/1000]`, `Step: [500/100000]`).
+    *   **Valores de Loss:** Métricas cruciales que indican qué tan bien está aprendiendo el modelo. Espera ver `train_loss` (loss del batch actual) y, periódicamente, `validation_loss` (loss sobre el conjunto de validación no visto). Ambos deberían generalmente disminuir con el tiempo. También podrían reportarse componentes de loss específicos (como `mel_loss`, `duration_loss`, `kl_loss`) según la arquitectura del modelo.
+    *   **Tasa de Aprendizaje:** La tasa de aprendizaje actual podría imprimirse, especialmente si un scheduler la está reduciendo con el tiempo.
+    *   **Marcas de Tiempo/Velocidad:** El tiempo que toma cada paso o epoch.
+-   **TensorBoard (Muy Recomendado):** Si está habilitado en tu configuración, usa TensorBoard para una monitorización visual.
+    *   **Lanzamiento:** Abre una *nueva* terminal (mantén la del entrenamiento ejecutándose), activa el mismo entorno virtual y ejecuta:
+        ```bash
+        # Apunta logdir al output_directory especificado en tu configuración
+        tensorboard --logdir ../checkpoints/my_yoruba_voice_run1
+        ```
+    *   **Acceso:** Abre la URL proporcionada por TensorBoard (normalmente `http://localhost:6006/`) en tu navegador web.
+    *   **Visualiza:** Puedes ver gráficos de los losses de entrenamiento y validación a lo largo del tiempo, las programaciones de la tasa de aprendizaje y, potencialmente, otras métricas.
+    *   **Escucha Muestras de Audio:** Muchos frameworks registran muestras de audio sintetizadas del conjunto de validación en TensorBoard de forma periódica (consulta la pestaña `AUDIO`). Escuchar estas muestras es la *mejor* manera de evaluar cualitativamente la mejora del modelo e identificar problemas como ruido, errores de pronunciación o salida robótica.
+-   **Directorio de Salida:** Comprueba el `output_directory` que especificaste en tu configuración (`../checkpoints/my_yoruba_voice_run1`). Debería contener:
+    *   Checkpoints del modelo guardados (archivos `.pth`, `.pt`, `.ckpt`).
+    *   Archivos de registro (logs) (`train.log`, etc.).
+    *   Copias del archivo de configuración utilizado.
+    *   Archivos de eventos de TensorBoard (normalmente en un subdirectorio `logs` o `events`).
+    *   Posiblemente muestras de audio sintetizadas.
+
+### 5.3. Entendiendo los Checkpoints
+
+-   **Qué son:** Los checkpoints son instantáneas del estado del modelo (todos sus pesos aprendidos y, potencialmente, el estado del optimizador) guardadas en intervalos específicos durante el entrenamiento.
+-   **Por qué importan:**
+    *   **Reanudar el Entrenamiento:** Te permiten continuar el entrenamiento si se interrumpe (debido a fallos, cortes de energía o detenciones manuales).
+    *   **Evaluar el Progreso:** Puedes usar checkpoints de diferentes etapas para sintetizar audio y ver cómo evolucionó el modelo.
+    *   **Seleccionar el Mejor Modelo:** El validation loss ayuda a identificar buenos checkpoints, pero el *mejor* modelo a menudo se elige escuchando el audio sintetizado de varios checkpoints prometedores cercanos al validation loss más bajo. A veces, un checkpoint ligeramente anterior suena mejor que el del loss más bajo en términos absolutos.
+-   **Frecuencia de Guardado:** Configura el `save_checkpoint_interval` en tu configuración. Guardar con demasiada frecuencia consume espacio en disco; guardar con muy poca frecuencia arriesga perder un progreso significativo si ocurre un fallo. Guardar cada pocos miles de pasos o una vez por epoch es común. Muchos frameworks también guardan automáticamente el "mejor" checkpoint según el validation loss.
+
+### 5.4. Reanudando un Entrenamiento Interrumpido
+
+-   Si tu entrenamiento se detiene inesperadamente o lo detienes manualmente, normalmente puedes reanudarlo desde el último checkpoint guardado.
+-   Encuentra la ruta al archivo de checkpoint más reciente en tu directorio de salida (por ejemplo, `../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth` o `latest_checkpoint.pth`).
+-   Usa el argumento de reanudación del framework al lanzar el script de entrenamiento de nuevo. El nombre del argumento varía:
+    ```bash
+    # Ejemplo usando --resume_checkpoint
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --resume_checkpoint ../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth
+
+    # Ejemplo usando --restore_path o --resume_path
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --restore_path ../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth
+    ```
+-   El script debería cargar los pesos del modelo y el estado del optimizador desde el checkpoint y continuar el entrenamiento desde ese punto.
+
+### 5.5. Cuándo Detener el Entrenamiento
+
+-   **Límite de Epochs:** El entrenamiento se detiene automáticamente cuando se alcanza el número máximo de `epochs` especificado en la configuración.
+-   **Early Stopping (parada temprana):** Monitoriza el `validation_loss`. Si deja de disminuir y comienza a aumentar de forma consistente durante un período prolongado (por ejemplo, a lo largo de varios intervalos de validación), el modelo podría estar empezando a sobreajustar (overfit). Podrías considerar detener el entrenamiento manualmente alrededor del punto donde el validation loss fue más bajo.
+-   **Evaluación Cualitativa:** Escucha regularmente las muestras de audio de validación generadas en TensorBoard o sintetiza muestras manualmente usando checkpoints recientes. Detén el entrenamiento cuando estés satisfecho con la calidad y la estabilidad del audio, incluso si el loss aún está disminuyendo ligeramente. Un entrenamiento adicional podría no producir mejoras perceptibles o incluso degradar la calidad.
+
+---
+
+## 6. Fine-tuning vs. Entrenamiento desde Cero
+
+### 6.1. Eligiendo tu Enfoque
+
+Al iniciar un proyecto de TTS, una de las decisiones más importantes es si hacer fine-tuning de un modelo existente o entrenar uno nuevo desde cero. Esta tabla te ayuda a decidir qué enfoque es mejor para tu situación específica:
+
+| Factor | Fine-tuning | Entrenamiento desde Cero |
+|:-------|:------------|:----------------------|
+| **Tamaño del Dataset** | Funciona bien con datasets más pequeños (5-20 horas)<br>Puede producir buenos resultados con tan solo 1-2 horas para algunas voces | Normalmente requiere datasets más grandes (30+ horas)<br>Menos de 20 horas a menudo conduce a una calidad pobre |
+| **Similitud de Voz** | Mejor cuando tu voz objetivo es similar a las voces de los datos de entrenamiento del modelo preentrenado | Necesario cuando tu voz objetivo es muy única o significativamente diferente de los modelos preentrenados disponibles |
+| **Idioma** | Funciona bien si se hace fine-tuning dentro del mismo idioma<br>Puede funcionar para casos interlingües con una preparación cuidadosa | Requerido para idiomas sin modelos preentrenados disponibles<br>Mejor para capturar la fonética específica del idioma |
+| **Tiempo de Entrenamiento** | Mucho más rápido (días en lugar de semanas)<br>Requiere menos epochs para converger | Tiempo de entrenamiento significativamente más largo<br>Puede requerir de 2 a 5 veces más epochs |
+| **Requisitos de Hardware** | Requisitos de GPU similares pero durante menos tiempo<br>A menudo puede usar tamaños de batch más pequeños | Necesita acceso sostenido a la GPU durante períodos más largos<br>Puede beneficiarse más de configuraciones multi-GPU |
+| **Potencial de Calidad** | Puede alcanzar una calidad excelente rápidamente<br>Puede heredar las limitaciones del modelo base | Máxima flexibilidad y potencial de calidad<br>Sin restricciones de un entrenamiento previo |
+| **Estabilidad** | Proceso de entrenamiento generalmente más estable<br>Menos propenso al colapso o a la no convergencia | Más sensible a los hiperparámetros<br>Mayor riesgo de inestabilidad en el entrenamiento |
+
+#### Cuándo Elegir Fine-tuning
+
+El fine-tuning se recomienda generalmente cuando:
+- Tienes datos limitados (menos de 20 horas)
+- Necesitas resultados más rápidos
+- Tu voz/idioma objetivo es razonablemente similar a los modelos preentrenados disponibles
+- Tienes recursos computacionales limitados
+- Eres nuevo en el entrenamiento de TTS (el fine-tuning es más indulgente)
+
+#### Cuándo Elegir Entrenamiento desde Cero
+
+El entrenamiento desde cero es mejor cuando:
+- Tienes abundantes datos (30+ horas)
+- Tu voz objetivo es muy única o tiene características no representadas en los modelos preentrenados
+- Trabajas con un idioma que está pobremente soportado por los modelos existentes
+- Necesitas el máximo control sobre todos los aspectos del modelo
+- Tienes acceso a recursos computacionales significativos
+- Estás construyendo un modelo base (foundation model) que otros harán fine-tuning
+
+### 6.2. Aspectos Específicos del Fine-tuning
+
+El fine-tuning aprovecha un potente modelo preentrenado y lo adapta a tu dataset específico (locutor, idioma, estilo). Normalmente es más rápido y requiere menos datos que el entrenamiento desde cero.
+
+#### El Objetivo
+
+-   Transferir las capacidades generales de síntesis de voz (como entender el mapeo de texto a sonido, la prosodia básica) del gran dataset con el que se entrenó el modelo base, mientras se especializa la identidad de la voz y, potencialmente, el acento/estilo para que coincidan con tu dataset más pequeño y específico.
+
+### 6.2. Diferencias Clave en la Configuración (Resumen de la Configuración)
+
+-   **`pretrained_model_path`:** DEBES proporcionar la ruta al archivo de checkpoint del modelo preentrenado en tu configuración.
+-   **`fine_tuning: True`:** Asegúrate de que cualquier indicador (flag) que señale el modo de fine-tuning esté habilitado si el framework lo requiere.
+-   **Tasa de Aprendizaje (Learning Rate):** Empieza con una tasa de aprendizaje *más baja* que la usada típicamente para el entrenamiento desde cero (por ejemplo, `1e-5`, `2e-5`, `5e-5`). Una tasa de aprendizaje alta puede destruir la valiosa información aprendida por el modelo preentrenado.
+-   **Batch Size:** A menudo puede ser similar al del entrenamiento desde cero, ajústalo según la VRAM.
+-   **Epochs:** El número de epochs requerido para el fine-tuning suele ser significativamente menor que para el entrenamiento desde cero, pero aún depende del tamaño del dataset y de la calidad deseada. Monitoriza de cerca el validation loss y las muestras de audio.
+
+### 6.3. Estrategias Potenciales (Dependientes del Framework)
+
+-   **Fine-tuning de Red Completa (Full Network):** El enfoque por defecto suele ser actualizar los pesos de toda la red, pero con una tasa de aprendizaje baja.
+-   **Congelación de Capas (Freezing Layers):** Algunos frameworks permiten congelar partes de la red (por ejemplo, el codificador de texto o el predictor de duración) inicialmente y entrenar solo componentes específicos (como los speaker embeddings o el decodificador). Esto a veces puede ayudar a preservar las fortalezas del modelo base mientras se adaptan aspectos específicos. Consulta la documentación de tu framework para ver opciones como `--freeze_layers` o similares.
+-   **Ignorar Capas (Ignoring Layers):** Al cargar el modelo preentrenado, podrías querer `ignore_layers` (o `reinitialize_layers`) como la capa de salida final o la capa de speaker embedding, especialmente si tu dataset tiene un número diferente de locutores que el modelo preentrenado.
+
+### 6.4. Monitorizando el Fine-tuning
+
+-   **Mejora Inicial Rápida:** Deberías ver el validation loss caer relativamente rápido al principio a medida que el modelo se adapta a la voz objetivo.
+-   **Enfócate en la Calidad del Audio:** Presta mucha atención a las muestras de validación sintetizadas. ¿Se está desplazando la identidad de la voz hacia tu locutor objetivo? ¿Es el habla clara y estable? El fine-tuning a menudo trata más sobre la calidad perceptiva que sobre alcanzar el valor de loss mínimo absoluto.
+
+---
+
+## 7. Guía Completa de Resolución de Problemas
+
+Entrenar modelos TTS puede ser un reto, con muchos problemas potenciales. Esta sección proporciona soluciones para los problemas comunes que podrías encontrar.
+
+### 7.1. Mensajes de Error Comunes y Soluciones
+
+| Mensaje de Error | Causas Posibles | Soluciones |
+|:--------------|:----------------|:----------|
+| `CUDA out of memory` | • Batch size demasiado grande<br>• Modelo demasiado grande para la GPU<br>• Fuga de memoria (memory leak) | • Reduce el batch size<br>• Habilita gradient checkpointing<br>• Usa mixed precision training<br>• Reduce la longitud de la secuencia |
+| `RuntimeError: Expected tensor for argument #1 'indices' to have scalar type Long` | • Tipo de dato incorrecto en el dataset<br>• Tipos de tensor incompatibles | • Comprueba el preprocesamiento de datos<br>• Asegúrate de que todos los tensores tengan el dtype correcto<br>• Añade una conversión de tipo explícita |
+| `ValueError: too many values to unpack` | • Desajuste entre las salidas del modelo y las expectativas de la función de loss<br>• Formato de datos incorrecto | • Comprueba la estructura de salida del modelo<br>• Verifica la implementación de la función de loss<br>• Depura las salidas del data loader |
+| `FileNotFoundError: [Errno 2] No such file or directory` | • Rutas incorrectas en la configuración<br>• Archivos de datos faltantes | • Verifica todas las rutas de archivos<br>• Comprueba la integridad del archivo manifest<br>• Asegúrate de que los datos estén descargados/extraídos |
+| `KeyError: 'speaker_id'` | • Información del locutor faltante<br>• Formato de dataset incorrecto | • Comprueba el formato del dataset<br>• Verifica el archivo de mapeo de locutores<br>• Añade la información del locutor al manifest |
+| `Loss is NaN` | • Tasa de aprendizaje demasiado alta<br>• Inicialización inestable<br>• Explosión de gradientes | • Reduce la tasa de aprendizaje<br>• Añade recorte de gradiente (gradient clipping)<br>• Comprueba si hay división por cero<br>• Normaliza los datos de entrada |
+| `ModuleNotFoundError: No module named 'X'` | • Dependencia faltante<br>• Problema con el entorno | • Instala el paquete faltante<br>• Comprueba el entorno virtual<br>• Verifica las versiones de los paquetes |
+| `RuntimeError: expected scalar type Float but found Double` | • Tipos de tensor inconsistentes | • Añade `.float()` a los tensores<br>• Comprueba el preprocesamiento de datos<br>• Estandariza el dtype en todo el modelo |
+
+### 7.2. Problemas de Calidad del Entrenamiento
+
+| Síntoma | Causas Posibles | Soluciones |
+|:--------|:----------------|:----------|
+| **Audio Robótico/Zumbante** | • Problemas con el vocoder<br>• Entrenamiento insuficiente<br>• Mal preprocesamiento del audio | • Entrena el vocoder durante más tiempo<br>• Comprueba la normalización del audio<br>• Verifica la consistencia del sampling rate |
+| **Omisión/Repetición de Palabras** | • Problemas de atención<br>• Entrenamiento inestable<br>• Datos insuficientes | • Usa guided attention loss<br>• Añade más variedad de datos<br>• Reduce la tasa de aprendizaje<br>• Comprueba si hay silencios largos en los datos |
+| **Pronunciación Incorrecta** | • Problemas de normalización de texto<br>• Errores de fonemas<br>• Desajuste de idioma | • Mejora el preprocesamiento de texto<br>• Usa entrada basada en fonemas<br>• Añade un diccionario de pronunciación |
+| **Pérdida de Identidad del Locutor** | • Overfitting al locutor dominante<br>• Speaker embeddings débiles<br>• Datos de locutor insuficientes | • Equilibra los datos de los locutores<br>• Aumenta la dimensión del speaker embedding<br>• Usa speaker adversarial loss |
+| **Convergencia Lenta** | • Problemas con la tasa de aprendizaje<br>• Mala inicialización<br>• Dataset complejo | • Prueba diferentes programaciones de LR<br>• Usa transfer learning<br>• Simplifica el dataset inicialmente |
+| **Entrenamiento Inestable** | • Varianza entre batches<br>• Valores atípicos en el dataset<br>• Problemas con el optimizador | • Usa gradient accumulation<br>• Limpia las muestras atípicas<br>• Prueba diferentes optimizadores |
+
+### 7.3. Problemas Específicos del Framework
+
+#### Coqui TTS
+```
+# Error: "RuntimeError: Error in applying gradient to param_name"
+# Solución: comprueba si hay valores NaN en tu dataset o reduce la tasa de aprendizaje
+python -c "import torch; torch.autograd.set_detect_anomaly(True)"  # Ejecuta antes del entrenamiento para depurar
+
+# Error: "ValueError: Tacotron training requires `r` > 1"
+# Solución: establece el factor de reducción correctamente en la configuración
+# Ejemplo de corrección en config.json:
+"r": 2  # Prueba valores entre 2-5
+```
+
+#### ESPnet
+```
+# Error: "TypeError: forward() missing 1 required positional argument: 'feats'"
+# Solución: comprueba el formato de los datos y asegúrate de que se proporcionan los feats
+# Depura la carga de datos:
+python -c "from espnet2.train.dataset import ESPnetDataset; dataset = ESPnetDataset(...); print(dataset[0])"
+```
+
+#### VITS/StyleTTS
+```
+# Error: "RuntimeError: expected scalar type Half but found Float"
+# Solución: asegura una precisión consistente en todo el modelo
+# Añade a tu script de entrenamiento:
+model = model.half()  # Si usas mixed precision
+# O
+model = model.float()  # Si no usas mixed precision
+```
+
+### 7.4. Problemas de Hardware y Entorno
+
+1. **Fragmentación de la Memoria de la GPU**
+   - **Síntoma**: errores OOM tras varias horas de entrenamiento a pesar de tener suficiente VRAM
+   - **Solución**: reinicia periódicamente el entrenamiento desde un checkpoint, usa batches más pequeños
+
+2. **Cuellos de Botella de la CPU**
+   - **Síntoma**: la utilización de la GPU fluctúa o se mantiene baja
+   - **Solución**: aumenta num_workers en el DataLoader, usa almacenamiento más rápido, precachea los datasets
+
+3. **Cuellos de Botella de E/S de Disco (Disk I/O)**
+   - **Síntoma**: el entrenamiento se detiene periódicamente durante la carga de datos
+   - **Solución**: usa almacenamiento SSD, aumenta el factor de prefetch, cachea el dataset en RAM
+
+4. **Conflictos de Entorno**
+   - **Síntoma**: fallos misteriosos o errores de importación
+   - **Solución**: usa entornos aislados (conda/venv), comprueba la compatibilidad de CUDA/PyTorch
+
+### 7.5. Estrategias de Depuración
+
+1. **Aísla el Problema**
+   ```bash
+   # Prueba la carga de datos por separado
+   python -c "from your_framework import DataLoader; loader = DataLoader(...); next(iter(loader))"
+   
+   # Prueba el paso hacia adelante (forward pass) con datos ficticios
+   python -c "import torch; from your_model import Model; model = Model(); x = torch.randn(1, 100); model(x)"
+   ```
+
+2. **Simplifica para Identificar Problemas**
+   - Entrena con un subconjunto diminuto (10-20 muestras)
+   - Desactiva temporalmente el aumento de datos (data augmentation)
+   - Prueba primero con un solo locutor
+
+3. **Visualiza las Salidas Intermedias**
+   - Grafica las alineaciones de atención (attention alignments)
+   - Visualiza los espectrogramas mel en diferentes etapas
+   - Monitoriza las normas de los gradientes
+
+4. **Habilita el Registro Detallado (Verbose Logging)**
+   ```bash
+   # Añade a tu script de entrenamiento
+   import logging
+   logging.basicConfig(level=logging.DEBUG)
+   ```
+
+5. **Usa el Profiling de TensorBoard**
+   ```python
+   # Añade a tu código de entrenamiento
+   from torch.profiler import profile, record_function
+   with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+       with record_function("model_inference"):
+           # Tu paso hacia adelante (forward pass)
+   print(prof.key_averages().table())
+   ```
+
+---
+
+Con el entrenamiento lanzado y monitorizado, el siguiente paso, tras seleccionar un buen checkpoint, es usar el modelo para generar voz a partir de texto nuevo.
+
+**Siguiente Paso:** [Inferencia](./4_INFERENCE.md){: .btn .btn-primary} | 
+[Volver Arriba](#top){: .btn .btn-primary}

--- a/languages/es/guides/4_INFERENCE.md
+++ b/languages/es/guides/4_INFERENCE.md
@@ -1,0 +1,426 @@
+# Guía 4: Inferencia - Generando Voz con tu Modelo
+
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Paso Anterior: Entrenamiento del Modelo](./3_MODEL_TRAINING.md){: .btn .btn-primary} | [Siguiente Paso: Empaquetado y Compartición](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+
+¡Has entrenado o hecho fine-tuning de un modelo TTS con éxito y seleccionado un checkpoint prometedor! Ahora, usemos ese modelo para convertir texto nuevo en audio de voz, un proceso llamado **inferencia** o **síntesis**.
+
+---
+
+## 7. Inferencia: Sintetizando Voz
+
+Esta sección explica cómo ejecutar el proceso de inferencia usando tu modelo entrenado.
+
+### 7.1. Localiza el Script de Inferencia y el Mejor Checkpoint
+
+-   **Script de Inferencia:** Encuentra el script de Python dentro de tu framework de TTS diseñado para generar audio. Los nombres comunes incluyen `inference.py`, `synthesize.py`, `infer.py`, `tts.py`.
+-   **Mejor Checkpoint:** Identifica la ruta al checkpoint del modelo (`.pth`, `.pt`, `.ckpt`) que quieres usar. Normalmente es el que se guarda como `best_model.pth` (basado en el validation loss) u otro checkpoint que seleccionaste tras escuchar las muestras de validación durante el entrenamiento. Estará ubicado dentro de tu directorio de salida del entrenamiento (por ejemplo, `../checkpoints/my_yoruba_voice_run1/best_model.pth`).
+-   **Archivo de Configuración:** Casi siempre necesitarás el archivo de configuración (`.yaml`, `.json`) que se usó *durante el entrenamiento* del checkpoint que estás usando. El script de inferencia lo necesita para conocer la arquitectura del modelo, los parámetros de audio (como el sampling rate) y otros ajustes. A menudo, se guarda una copia de la configuración junto a los checkpoints.
+
+### 7.2. Inferencia Básica de una Sola Frase
+
+-   **Objetivo:** Generar audio para una única pieza de texto proporcionada directamente a través de la línea de comandos.
+-   **Estructura del Comando:** Los argumentos exactos variarán, pero un comando típico se ve así:
+
+    ```bash
+    # ¡Activa primero tu entorno virtual!
+    # Comando de ejemplo:
+    python inference.py \
+      --config ../checkpoints/my_yoruba_voice_run1/config.yaml \
+      --checkpoint_path ../checkpoints/my_yoruba_voice_run1/best_model.pth \
+      --text "Hello, this is a test of my custom trained voice." \
+      --output_wav_path ./output_sample.wav
+      # Argumentos opcionales/dependientes del framework a continuación:
+      # --speaker_id "main_speaker"  # Necesario para modelos multi-locutor
+      # --device "cuda"              # Para especificar el uso de la GPU (a menudo por defecto)
+    ```
+-   **Argumentos Clave:**
+    *   `--config` o `-c`: Ruta al archivo de configuración del entrenamiento.
+    *   `--checkpoint_path` o `--model_path` o `-m`: Ruta al archivo de checkpoint del modelo.
+    *   `--text` o `-t`: La frase de entrada que quieres sintetizar. Recuerda encerrarla entre comillas.
+    *   `--output_wav_path` o `--out_path` o `-o`: La ruta y el nombre de archivo deseados para el archivo WAV generado.
+    *   `--speaker_id` o `--spk`: **Requerido** si entrenaste un modelo multi-locutor. Proporciona el speaker ID exacto usado en tus archivos manifest para la voz deseada. Para modelos de un solo locutor, esto podría ser opcional o ignorarse.
+    *   `--device`: A menudo opcional, por defecto es `cuda` si está disponible, de lo contrario `cpu`. La inferencia es mucho más rápida en GPU.
+
+-   **Ejecución:** Ejecuta el comando. Cargará el modelo, procesará el texto, generará la forma de onda del audio y la guardará en el archivo de salida especificado. Escucha el archivo WAV de salida para comprobar la calidad.
+
+### 7.3. Inferencia por Lotes (Sintetizando desde un Archivo)
+
+-   **Objetivo:** Generar audio para múltiples frases listadas en un archivo de texto, guardando cada una como un archivo WAV separado.
+-   **Prepara el Archivo de Entrada:** Crea un archivo de texto plano (por ejemplo, `sentences.txt`) donde cada línea contenga una frase que quieras sintetizar:
+    ```text
+    Esta es la primera frase.
+    Aquí hay otra frase para sintetizar.
+    El modelo debería manejar diferentes signos de puntuación, ¿como las preguntas?
+    ¡Y también las exclamaciones!
+    ```
+-   **Estructura del Comando:** Muchos frameworks proporcionan un script separado o argumentos específicos para el procesamiento por lotes.
+
+    ```bash
+    # Comando de ejemplo (el nombre del script y los argumentos pueden variar):
+    python inference_batch.py \
+      --config ../checkpoints/my_yoruba_voice_run1/config.yaml \
+      --checkpoint_path ../checkpoints/my_yoruba_voice_run1/best_model.pth \
+      --input_file sentences.txt \
+      --output_dir ./generated_batch_audio/
+      # Argumentos opcionales/dependientes del framework a continuación:
+      # --speaker_id "main_speaker"  # Necesario para modelos multi-locutor
+      # --device "cuda"
+    ```
+-   **Argumentos Clave:**
+    *   `--input_file` o `--text_file`: Ruta al archivo de texto que contiene las frases (una por línea).
+    *   `--output_dir` o `--out_dir`: Ruta al directorio donde se deben guardar los archivos WAV generados. Asegúrate de que este directorio exista o de que el script lo cree. Los nombres de archivo de salida a menudo se basan en el número de línea o en el propio texto de entrada (por ejemplo, `output_0.wav`, `output_1.wav`).
+    *   Otros argumentos (`--config`, `--checkpoint_path`, `--speaker_id`, `--device`) son normalmente los mismos que para la inferencia de una sola frase.
+
+-   **Ejecución:** Ejecuta el comando. El script iterará por cada línea del archivo de entrada, sintetizará el audio y guardará los resultados en el directorio de salida especificado.
+
+### 7.4. Inferencia de Modelos Multi-Locutor
+
+-   Como se mencionó anteriormente, si tu modelo fue entrenado con datos de múltiples locutores, **debes** especificar qué voz de locutor quieres usar durante la inferencia.
+-   Usa el argumento `--speaker_id` (o equivalente), proporcionando el ID exacto que corresponde al locutor deseado en tus archivos manifest de entrenamiento (por ejemplo, `speaker0`, `mary_smith`, `yoruba_male_spk1`).
+-   Si omites el speaker ID para un modelo multi-locutor, el script podría fallar, usar por defecto un locutor específico (a menudo el locutor 0), o producir resultados promediados/distorsionados.
+
+### 7.5. Controles de Inferencia Avanzados (Dependientes del Framework)
+
+-   Algunos modelos y frameworks de TTS avanzados ofrecen controles adicionales durante la inferencia, a menudo pasados como argumentos de línea de comandos o parámetros en una API de Python:
+    *   **Velocidad/Ritmo del Habla:** Argumentos como `--speed` o `--length_scale` podrían permitirte hacer que la voz hable más rápido o más lento (por ejemplo, `1.0` es normal, `<1.0` es más rápido, `>1.0` es más lento).
+    *   **Control de Tono (Pitch):** Menos común, pero algunos modelos podrían permitir ajustes de tono.
+    *   **Control de Estilo/Emoción:** Si el modelo fue entrenado con tokens de estilo o capacidades de audio de referencia (como StyleTTS2 o modelos con style embeddings), podrías proporcionar argumentos como `--style_text` o `--style_wav` para influir en la prosodia o la emoción de la salida.
+    *   **Ajustes del Vocoder (si aplica):** Para modelos más antiguos al estilo Tacotron2 u otros que usan modelos de vocoder separados (como HiFi-GAN, MelGAN), podría haber ajustes relacionados con el vocoder (por ejemplo, la intensidad del denoising).
+    *   **Modelos de Difusión:** Para los modelos TTS basados en difusión, podrían estar disponibles parámetros que controlen el número de pasos de difusión (intercambiando calidad por velocidad).
+-   **Consulta la Documentación:** Siempre consulta la documentación de tu framework de TTS específico o la ayuda del script de inferencia (`python inference.py --help`) para ver qué controles están disponibles.
+
+### 7.6. Problemas Potenciales de la Inferencia
+
+-   **CUDA Out-of-Memory (OOM):** Aunque el entrenamiento haya funcionado, las frases muy largas durante la inferencia podrían consumir más memoria. Prueba con frases más cortas o comprueba si el framework ofrece opciones para la síntesis segmentada. Ejecutar en CPU (`--device cpu`) usa la RAM del sistema, pero es significativamente más lento.
+-   **Desajuste de Modelo/Configuración:** Usar un checkpoint con el archivo de configuración incorrecto es un error común que conduce a fallos de carga o a una salida basura. Asegúrate de que correspondan a la misma ejecución de entrenamiento.
+-   **Speaker ID Incorrecto:** Proporcionar un speaker ID inexistente para modelos multi-locutor causará errores.
+-   **Problemas de Calidad (Ruido, Inestabilidad):** Si la calidad de la salida es pobre, revisa la Guía 1 (Preparación de Datos) y la Guía 3 (Entrenamiento del Modelo). Podría indicar problemas con la calidad de los datos, un entrenamiento insuficiente o la elección de un checkpoint subóptimo.
+
+---
+
+## 8. Evaluación y Despliegue del Modelo
+
+### 8.1. Evaluando la Calidad del Modelo TTS
+
+Si bien las pruebas de escucha subjetivas son el estándar de oro para la evaluación de TTS, también existen métricas objetivas que pueden ayudar a cuantificar el rendimiento de tu modelo:
+
+#### Métricas de Evaluación Objetivas
+
+| Métrica | Qué Mide | Herramientas/Implementación | Interpretación |
+|:-------|:-----------------|:---------------------|:---------------|
+| **MOS (Mean Opinion Score)** | Calidad percibida general | Evaluadores humanos valoran las muestras en una escala de 1 a 5 | Más alto es mejor; estándar de la industria pero requiere evaluadores humanos |
+| **PESQ (Perceptual Evaluation of Speech Quality)** | Calidad del audio comparada con una referencia | Disponible en Python vía `pypesq` | Rango: -0.5 a 4.5; más alto es mejor |
+| **STOI (Short-Time Objective Intelligibility)** | Inteligibilidad del habla | Disponible en Python vía `pystoi` | Rango: 0 a 1; más alto es mejor |
+| **Tasa de Error de Caracteres/Palabras (CER/WER)** | Inteligibilidad mediante ASR | Ejecuta ASR sobre la voz sintetizada y compara con el texto de entrada | Más bajo es mejor; mide si las palabras se pronuncian correctamente |
+| **Mel Cepstral Distortion (MCD)** | Distancia espectral respecto a la referencia | Implementación personalizada usando librosa | Más bajo es mejor; típicamente 2-8 para sistemas TTS |
+| **F0 RMSE** | Precisión del tono (pitch) | Implementación personalizada usando librosa | Más bajo es mejor; mide la precisión del contorno de tono |
+| **Error en la Decisión de Sonoridad (Voicing)** | Precisión sonora/sorda (voiced/unvoiced) | Implementación personalizada | Más bajo es mejor; mide si el habla/silencio se coloca correctamente |
+
+#### Enfoque Práctico de Evaluación
+
+1. **Prepara el Conjunto de Prueba**: Crea un conjunto de frases de prueba diversas no vistas durante el entrenamiento
+   ```
+   # Ejemplo de test_sentences.txt
+   Esta es una simple frase declarativa.
+   ¿Es esta una frase interrogativa?
+   ¡Vaya! ¡Esta es una frase exclamativa!
+   Esta frase contiene números como 123 y símbolos como %.
+   Esta es una frase mucho más larga que continúa durante bastante tiempo, poniendo a prueba la capacidad del modelo para mantener la coherencia y una prosodia adecuada a lo largo de enunciados más largos con múltiples cláusulas y oraciones.
+   ```
+
+2. **Genera Muestras**: Usa tu modelo para sintetizar voz para todas las frases de prueba
+
+3. **Realiza Pruebas de Escucha**: Haz que varios oyentes valoren las muestras según:
+   - Naturalidad (escala de 1 a 5)
+   - Calidad del audio/artefactos (escala de 1 a 5)
+   - Precisión de la pronunciación (escala de 1 a 5)
+   - Similitud del locutor (escala de 1 a 5, si se clona una voz específica)
+
+4. **Implementa Métricas Objetivas**: Este fragmento de Python demuestra cómo calcular algunas métricas básicas:
+
+   ```python
+   import numpy as np
+   import librosa
+   from pesq import pesq
+   from pystoi import stoi
+   import torch
+   from transformers import pipeline
+
+   def evaluate_tts_sample(generated_audio_path, reference_audio_path=None, original_text=None):
+       """Evalúa una muestra de TTS usando varias métricas."""
+       results = {}
+       
+       # Carga el audio generado
+       y_gen, sr_gen = librosa.load(generated_audio_path, sr=None)
+       
+       # Estadísticas básicas del audio
+       results["duration"] = librosa.get_duration(y=y_gen, sr=sr_gen)
+       results["rms_energy"] = np.sqrt(np.mean(y_gen**2))
+       
+       # Si hay audio de referencia disponible, calcula métricas de comparación
+       if reference_audio_path:
+           y_ref, sr_ref = librosa.load(reference_audio_path, sr=sr_gen)  # Iguala los sampling rates
+           
+           # Asegura la misma longitud para la comparación
+           min_len = min(len(y_gen), len(y_ref))
+           y_gen_trim = y_gen[:min_len]
+           y_ref_trim = y_ref[:min_len]
+           
+           # PESQ (requiere audio de 16kHz u 8kHz)
+           if sr_gen in [8000, 16000]:
+               try:
+                   results["pesq"] = pesq(sr_gen, y_ref_trim, y_gen_trim, 'wb')
+               except Exception as e:
+                   results["pesq"] = f"Error: {str(e)}"
+           else:
+               results["pesq"] = "Requires 8kHz or 16kHz audio"
+           
+           # STOI
+           try:
+               results["stoi"] = stoi(y_ref_trim, y_gen_trim, sr_gen, extended=False)
+           except Exception as e:
+               results["stoi"] = f"Error: {str(e)}"
+       
+       # Si hay texto original disponible, realiza ASR y calcula WER/CER
+       if original_text:
+           try:
+               # Carga el modelo ASR (requiere transformers y torch)
+               asr = pipeline("automatic-speech-recognition", model="openai/whisper-small")
+               
+               # Transcribe el audio generado
+               transcription = asr(generated_audio_path)["text"].strip().lower()
+               original_text = original_text.strip().lower()
+               
+               results["transcription"] = transcription
+               results["original_text"] = original_text
+               
+               # Cálculo simple de la tasa de error de caracteres
+               def cer(ref, hyp):
+                   ref, hyp = ref.lower(), hyp.lower()
+                   return levenshtein_distance(ref, hyp) / len(ref)
+               
+               def levenshtein_distance(s1, s2):
+                   if len(s1) < len(s2):
+                       return levenshtein_distance(s2, s1)
+                   if len(s2) == 0:
+                       return len(s1)
+                   previous_row = range(len(s2) + 1)
+                   for i, c1 in enumerate(s1):
+                       current_row = [i + 1]
+                       for j, c2 in enumerate(s2):
+                           insertions = previous_row[j + 1] + 1
+                           deletions = current_row[j] + 1
+                           substitutions = previous_row[j] + (c1 != c2)
+                           current_row.append(min(insertions, deletions, substitutions))
+                       previous_row = current_row
+                   return previous_row[-1]
+               
+               results["character_error_rate"] = cer(original_text, transcription)
+           except Exception as e:
+               results["asr_error"] = str(e)
+       
+       return results
+   ```
+
+### 8.2. Desplegando Modelos TTS
+
+Una vez que has entrenado y evaluado tu modelo, es posible que quieras desplegarlo para un uso práctico. Aquí tienes algunas opciones de despliegue:
+
+#### Consideraciones para el Despliegue en Producción
+
+Al pasar de la experimentación al despliegue en producción, considera estos factores importantes:
+
+1. **Optimización del Modelo**
+   - **Cuantización (Quantization)**: reduce la precisión del modelo de FP32 a FP16 o INT8 para disminuir el tamaño y aumentar la velocidad de inferencia
+   - **Poda (Pruning)**: elimina pesos innecesarios para crear modelos más pequeños y rápidos
+   - **Destilación de Conocimiento (Knowledge Distillation)**: entrena un modelo "estudiante" más pequeño para imitar a tu modelo "profesor" más grande
+   - **Conversión a ONNX**: convierte tu modelo de PyTorch/TensorFlow a formato ONNX para un mejor rendimiento multiplataforma
+
+2. **Optimización de la Latencia**
+   - **Procesamiento por Lotes (Batch Processing)**: para aplicaciones que no son en tiempo real, procesa múltiples solicitudes en lotes
+   - **Síntesis en Streaming**: para aplicaciones en tiempo real, implementa un procesamiento segmento a segmento
+   - **Caché (Caching)**: cachea las frases o secuencias de fonemas solicitadas con frecuencia
+   - **Aceleración por Hardware**: utiliza GPU/TPU para el procesamiento paralelo o hardware especializado como NVIDIA TensorRT
+
+3. **Escalabilidad**
+   - **Contenerización (Containerization)**: empaqueta tu modelo y sus dependencias en contenedores Docker
+   - **Kubernetes**: orquesta múltiples contenedores para alta disponibilidad y balanceo de carga
+   - **Autoescalado (Auto-scaling)**: ajusta automáticamente los recursos según la demanda
+   - **Sistemas de Colas (Queue Systems)**: implementa colas de solicitudes (RabbitMQ, Kafka) para gestionar picos de tráfico
+
+4. **Monitorización y Mantenimiento**
+   - **Métricas de Rendimiento**: monitoriza la latencia, el rendimiento (throughput), las tasas de error y la utilización de recursos
+   - **Monitorización de la Calidad**: muestrea y evalúa periódicamente la calidad de la salida
+   - **Pruebas A/B**: compara diferentes versiones del modelo en producción
+   - **Entrenamiento Continuo**: configura pipelines para reentrenar los modelos con nuevos datos
+
+#### Arquitectura de Ejemplo para Despliegue en Producción
+
+```
+[Aplicaciones Cliente] → [Balanceador de Carga] → [Pasarela de API (API Gateway)]
+                                             ↓
+[Validación de Solicitudes] → [Limitación de Tasa (Rate Limiting)] → [Autenticación]
+                                             ↓
+[Cola de Solicitudes] → [Pods de Workers TTS (Kubernetes)] → [Caché de Audio]
+                         ↓                              ↑
+                  [Contenedor del Modelo TTS]                 |
+                         ↓                              |
+                  [Postprocesamiento de Audio] → [Almacenamiento de Audio]
+```
+
+#### Opciones de Despliegue Local
+
+1. **Interfaz de Línea de Comandos**: el enfoque más simple es crear un script que envuelva el código de inferencia:
+
+   ```python
+   # tts_cli.py
+   import argparse
+   import os
+   import torch
+   
+   # Importa aquí tus módulos específicos del modelo
+   # from your_tts_framework import load_model, synthesize_text
+   
+   def main():
+       parser = argparse.ArgumentParser(description="Text-to-Speech CLI")
+       parser.add_argument("--text", type=str, required=True, help="Text to synthesize")
+       parser.add_argument("--model", type=str, required=True, help="Path to model checkpoint")
+       parser.add_argument("--config", type=str, required=True, help="Path to model config")
+       parser.add_argument("--output", type=str, default="output.wav", help="Output audio file path")
+       parser.add_argument("--speaker", type=str, default=None, help="Speaker ID for multi-speaker models")
+       args = parser.parse_args()
+       
+       # Carga el modelo (la implementación depende de tu framework)
+       model = load_model(args.model, args.config)
+       
+       # Sintetiza la voz
+       audio = synthesize_text(model, args.text, speaker_id=args.speaker)
+       
+       # Guarda el audio
+       save_audio(audio, args.output)
+       print(f"Audio saved to {args.output}")
+   
+   if __name__ == "__main__":
+       main()
+   ```
+
+2. **Interfaz Web Simple**: crea una interfaz web básica usando Flask o Gradio:
+
+   ```python
+   # app.py (ejemplo con Flask)
+   from flask import Flask, request, send_file, render_template
+   import os
+   import torch
+   import uuid
+   
+   # Importa aquí tus módulos específicos del modelo
+   # from your_tts_framework import load_model, synthesize_text
+   
+   app = Flask(__name__)
+   
+   # Carga el modelo al inicio (para una inferencia más rápida)
+   MODEL_PATH = "path/to/best_model.pth"
+   CONFIG_PATH = "path/to/config.yaml"
+   model = load_model(MODEL_PATH, CONFIG_PATH)
+   
+   @app.route('/')
+   def index():
+       return render_template('index.html')
+   
+   @app.route('/synthesize', methods=['POST'])
+   def synthesize():
+       text = request.form['text']
+       speaker_id = request.form.get('speaker_id', None)
+       
+       # Genera un nombre de archivo único
+       output_file = f"static/audio/{uuid.uuid4()}.wav"
+       os.makedirs(os.path.dirname(output_file), exist_ok=True)
+       
+       # Sintetiza la voz
+       audio = synthesize_text(model, text, speaker_id=speaker_id)
+       
+       # Guarda el audio
+       save_audio(audio, output_file)
+       
+       return {'audio_path': output_file}
+   
+   if __name__ == '__main__':
+       app.run(host='0.0.0.0', port=5000, debug=True)
+   ```
+
+3. **Interfaz con Gradio** (Aún más simple):
+
+   ```python
+   import gradio as gr
+   import torch
+   
+   # Importa aquí tus módulos específicos del modelo
+   # from your_tts_framework import load_model, synthesize_text
+   
+   # Carga el modelo
+   MODEL_PATH = "path/to/best_model.pth"
+   CONFIG_PATH = "path/to/config.yaml"
+   model = load_model(MODEL_PATH, CONFIG_PATH)
+   
+   def tts_function(text, speaker_id=None):
+       # Sintetiza la voz
+       audio = synthesize_text(model, text, speaker_id=speaker_id)
+       sampling_rate = 22050  # Ajusta a la frecuencia de tu modelo
+       return (sampling_rate, audio)
+   
+   # Crea la interfaz de Gradio
+   iface = gr.Interface(
+       fn=tts_function,
+       inputs=[
+           gr.Textbox(lines=3, placeholder="Enter text to synthesize..."),
+           gr.Dropdown(choices=["speaker1", "speaker2"], label="Speaker", visible=True)  # Para modelos multi-locutor
+       ],
+       outputs=gr.Audio(type="numpy"),
+       title="Text-to-Speech Demo",
+       description="Enter text and generate speech using a custom TTS model."
+   )
+   
+   iface.launch(server_name="0.0.0.0", server_port=7860)
+   ```
+
+#### Opciones de Despliegue en la Nube
+
+Para uso en producción, considera estas opciones:
+
+1. **Hugging Face Spaces**: sube tu modelo a Hugging Face y crea una app de Gradio o Streamlit
+2. **API REST**: envuelve tu modelo en una aplicación FastAPI o Flask y despliégala en servicios en la nube
+3. **Funciones Serverless**: para modelos ligeros, despliégalos como funciones serverless (AWS Lambda, Google Cloud Functions)
+4. **Contenedores Docker**: empaqueta tu modelo y sus dependencias en un contenedor Docker para un despliegue consistente
+
+#### Optimización del Rendimiento
+
+Para mejorar la velocidad y eficiencia de la inferencia:
+
+1. **Cuantización del Modelo (Quantization)**: convierte los pesos del modelo a menor precisión (FP16 o INT8)
+   ```python
+   # Ejemplo de conversión a FP16 con PyTorch
+   model = model.half()  # Convierte a FP16
+   ```
+
+2. **Poda del Modelo (Pruning)**: elimina pesos innecesarios para crear modelos más pequeños
+3. **Conversión a ONNX**: convierte los modelos de PyTorch a formato ONNX para una inferencia más rápida
+   ```python
+   # Ejemplo de exportación a ONNX
+   import torch.onnx
+   
+   # Exporta el modelo
+   torch.onnx.export(model,               # modelo que se está ejecutando
+                     dummy_input,         # entrada del modelo (o una tupla para múltiples entradas)
+                     "model.onnx",        # dónde guardar el modelo
+                     export_params=True,  # almacena los pesos de los parámetros entrenados dentro del archivo del modelo
+                     opset_version=11,    # la versión de ONNX a la que exportar el modelo
+                     do_constant_folding=True)  # optimización
+   ```
+
+4. **Procesamiento por Lotes (Batch Processing)**: procesa múltiples entradas de texto a la vez para un mayor rendimiento (throughput)
+5. **Caché (Caching)**: cachea las salidas solicitadas con frecuencia para evitar regenerarlas
+
+Ahora que puedes generar voz usando tu modelo entrenado, el siguiente paso lógico es organizar correctamente los archivos de tu modelo para su uso futuro, compartición o despliegue.
+
+**Siguiente Paso:** [Empaquetado y Compartición](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+[Volver Arriba](#top){: .btn .btn-primary}

--- a/languages/es/guides/5_PACKAGING_AND_SHARING.md
+++ b/languages/es/guides/5_PACKAGING_AND_SHARING.md
@@ -1,0 +1,129 @@
+# Guía 5: Empaquetado y Compartición de tu Modelo TTS
+
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Paso Anterior: Inferencia](./4_INFERENCE.md){: .btn .btn-primary} |  | [Siguiente Paso: Resolución de Problemas y Recursos](./6_TROUBLESHOOTING_AND_RESOURCES.md){: .btn .btn-primary} | 
+
+
+Has entrenado un modelo y puedes generar voz con él. ¡Felicidades! Para asegurar que tu modelo sea usable en el futuro (por ti o por otros) y para facilitar la reproducibilidad, un empaquetado y una documentación adecuados son esenciales.
+
+---
+
+## 9. Empaquetando tu Modelo Entrenado
+
+Piensa en tu modelo entrenado no solo como un único archivo `.pth`, sino como un paquete completo que contiene todo lo necesario para entenderlo y usarlo.
+
+### 9.1. Organiza los Archivos de tu Modelo
+
+Crea una estructura de directorios limpia y autocontenida para cada modelo entrenado distinto o versión significativa. Esto facilita encontrar todo más adelante.
+
+**Estructura de Ejemplo:**
+
+```
+my_tts_model_packages/
+└── yoruba_male_v1.0/         # Nombre descriptivo para este paquete de modelo
+    ├── checkpoints/          # Directorio para los pesos del modelo
+    │   ├── best_model.pth    # Checkpoint con el validation loss más bajo (o la mejor calidad percibida)
+    │   └── last_model.pth    # Checkpoint del final del entrenamiento (opcional, pero a veces útil)
+    │
+    ├── config.yaml           # El archivo de configuración EXACTO usado para entrenar ESTE checkpoint
+    │
+    ├── training_info.md      # Opcional: un archivo con logs/notas detallados del entrenamiento
+    │   ├── train_list.txt    # Copia del archivo manifest de entrenamiento usado
+    │   └── val_list.txt      # Copia del archivo manifest de validación usado
+    │
+    ├── samples/              # Directorio con audio de ejemplo generado por este modelo
+    │   ├── sample_short_sentence.wav
+    │   ├── sample_question.wav
+    │   └── sample_longer_paragraph.wav
+    │
+    └── README.md             # Esencial: documentación legible para este paquete de modelo específico
+```
+
+**Componentes Clave Explicados:**
+
+*   **`checkpoints/`**: Contiene los pesos reales del modelo. Incluye siempre el checkpoint considerado el 'mejor' (ya sea por el loss o por las pruebas de escucha). Incluir el checkpoint final también es una buena práctica.
+*   **`config.yaml` (o `.json`)**: Absolutamente crítico. Este archivo define la arquitectura del modelo y los parámetros necesarios para cargar y usar el checkpoint correctamente. Sin él, el checkpoint a menudo es inutilizable. Asegúrate de que sea la configuración *exacta* usada para los checkpoints incluidos.
+*   **`training_info.md` / Manifests (Opcional pero Recomendado):** Almacenar los manifests ayuda a rastrear exactamente con qué datos se entrenó el modelo. Un `training_info.md` puede contener notas sobre la ejecución del entrenamiento (duración, hardware utilizado, métricas finales, observaciones).
+*   **`samples/`**: Incluye unos cuantos ejemplos de audio diversos generados por el `best_model.pth`. Esto demuestra rápidamente la identidad de la voz, la calidad y las características del modelo.
+*   **`README.md`**: El manual de usuario de este paquete de modelo específico. Consulta la siguiente sección.
+
+### 9.2. Escribiendo un Buen README.md para el Modelo
+
+Este README es específico de *este paquete de modelo*, no de la guía general del proyecto. Debe indicarle a cualquiera (incluido tu yo futuro) todo lo que necesita saber para usar el modelo.
+
+**Plantilla Mínima:**
+
+```markdown
+# Paquete de Modelo TTS: Voz Masculina Yoruba v1.0
+
+## Descripción del Modelo
+- **Voz:** Voz masculina adulta y clara hablando yoruba.
+- **Calidad de los Datos Fuente:** Entrenado con ~25 horas de grabaciones limpias de radiodifusión.
+- **Idioma(s):** Yoruba (principalmente). Puede tener un manejo limitado de préstamos del inglés según los datos de entrenamiento.
+- **Estilo de Habla:** Estilo formal, narrativo/de radiodifusión.
+- **Arquitectura del Modelo:** [Especifica Framework/Arquitectura, p. ej., StyleTTS2, VITS]
+- **Versión:** 1.0
+
+## Detalles del Entrenamiento
+- **Basado En:** Fine-tuning a partir de [Especifica el modelo base, p. ej., modelo LibriTTS preentrenado] O Entrenado desde cero.
+- **Datos de Entrenamiento:** Consulta los archivos `train_list.txt` y `val_list.txt` incluidos. Total de horas: ~25h.
+- **Configuración Clave del Entrenamiento:** Consulta el archivo `config.yaml` incluido.
+- **Sampling Rate:** 22050 Hz (El audio de entrada debe coincidir con esta frecuencia para algunos frameworks).
+- **Tiempo de Entrenamiento:** Aprox. 48 horas en 1x NVIDIA RTX 3090.
+- **Información del Checkpoint:** `best_model.pth` seleccionado según el validation loss más bajo en el paso [XXXXX].
+
+## Cómo Usar para Inferencia
+1.  **Prerrequisitos:** Asegúrate de tener instalado el framework [Especifica el Nombre del Framework de TTS, p. ej., StyleTTS2], compatible con esta versión del modelo.
+2.  **Configuración:** Usa el archivo `config.yaml` incluido.
+3.  **Checkpoint:** Carga el archivo `checkpoints/best_model.pth`.
+4.  **Texto de Entrada:** Proporciona texto plano como entrada. La normalización del texto que coincida con los datos de entrenamiento (p. ej., la expansión de números) podría mejorar los resultados.
+5.  **Speaker ID (si aplica):** Este es un modelo de un solo locutor. Usa el speaker ID `[Especifica el ID usado, p. ej., main_speaker]` si lo requiere el framework, de lo contrario podría no ser necesario.
+6.  **Salida Esperada:** El audio se generará a un sampling rate de 22050 Hz.
+
+## Muestras de Audio
+Escucha ejemplos generados por este modelo:
+- [Frase Corta](./samples/sample_short_sentence.wav)
+- [Pregunta](./samples/sample_question.wav)
+- [Párrafo Más Largo](./samples/sample_longer_paragraph.wav)
+
+## Limitaciones Conocidas / Notas
+- El rendimiento puede degradarse en textos significativamente diferentes del dominio de la radiodifusión.
+- No modela explícitamente emociones matizadas.
+- [Añade cualquier otra observación relevante]
+
+## Licenciamiento
+- **Pesos del Modelo:** [Especifica la Licencia, p. ej., CC BY-NC-SA 4.0, Solo Uso de Investigación/No Comercial, Licencia MIT - ¡Sé preciso!]
+- **Datos Fuente:** [Menciona las restricciones de licencia de los datos fuente si afectan al uso del modelo, p. ej., "Entrenado con datos propietarios, modelo solo para uso interno."] **¡Consulta la licencia de tus datos de entrenamiento!**
+```
+
+### 9.3. Consejos para el Versionado del Modelo
+
+Trata tus modelos entrenados como lanzamientos de software (software releases).
+
+*   **Usa Versionado Semántico (Recomendado):** Usa nombres como `model_v1.0`, `model_v1.1`, `model_v2.0`.
+    *   Incrementa la versión PATCH (v1.0 -> v1.0.1) para correcciones menores/reentrenamientos con los mismos datos/configuración.
+    *   Incrementa la versión MINOR (v1.0 -> v1.1) para mejoras, reentrenamiento con más datos, ajustes significativos de configuración.
+    *   Incrementa la versión MAJOR (v1.0 -> v2.0) para cambios mayores de arquitectura o un reentrenamiento completo con datos/objetivos centrales diferentes.
+*   **Actualiza los README:** Al crear una nueva versión, actualiza su README para reflejar los cambios respecto a la versión anterior.
+*   **Conserva las Versiones Antiguas:** No descartes inmediatamente las versiones más antiguas. A veces un modelo anterior podría rendir mejor en tipos específicos de texto, o podrías necesitar revertir si una nueva versión introduce regresiones. Si el almacenamiento lo permite, archívalas.
+
+### 9.4. Consideraciones de Compartición y Distribución
+
+Si planeas compartir tu modelo:
+
+*   **Empaquetado:** Crea un archivo comprimido (por ejemplo, `.zip`, `.tar.gz`) de todo el directorio del paquete del modelo (que contiene los checkpoints, la configuración, el README, las muestras, etc.).
+*   **Plataformas de Alojamiento:**
+    *   **Hugging Face Hub (Models):** Excelente plataforma para compartir modelos, incluye versionado, tarjetas de modelo (model cards) (¡usa el contenido de tu README!) y, potencialmente, widgets de inferencia. Fácil para que otros lo descubran y lo usen.
+    *   **GitHub Releases:** Adecuado para modelos más pequeños, adjunta el archivo zip a una etiqueta de lanzamiento (release tag) en el repositorio de tu proyecto.
+    *   **Almacenamiento en la Nube (Google Drive, Dropbox, S3):** Simple para compartir directamente, pero menos descubrible y carece de funciones de versionado. Asegúrate de configurar correctamente los permisos del enlace.
+*   **Licenciamiento (CRÍTICO):**
+    *   **Tu Modelo:** Elige una licencia para los *pesos* del modelo que estás distribuyendo (por ejemplo, MIT, Apache 2.0 para licencias permisivas; CC BY-NC-SA para compartición no comercial).
+    *   **Dependencia de los Datos:** **De forma crucial, la licencia de tus datos de entrenamiento a menudo dicta cómo puedes licenciar tu modelo entrenado.** Si entrenaste con datos con una licencia no comercial, generalmente no puedes lanzar tu modelo bajo una licencia comercial permisiva. Si entrenaste con datos con copyright sin permiso, probablemente no puedas compartir el modelo públicamente en absoluto. **Siempre comprueba las licencias de tus fuentes de datos.**
+    *   **Licencia del Framework:** El código del framework de TTS en sí tiene su propia licencia, que es independiente de la licencia de tu modelo.
+    *   **Indica Claramente los Términos de Uso:** Usa el `README.md` dentro de tu paquete de modelo para indicar claramente el uso previsto (por ejemplo, solo investigación, no comercial, gratuito para cualquier uso) y los términos de la licencia.
+
+---
+
+Empaquetar y documentar correctamente tus modelos los hace significativamente más valiosos y usables, ya sea para tus propios proyectos futuros o para la colaboración y la compartición dentro de la comunidad.
+
+**Siguiente Paso:** [Resolución de Problemas y Recursos](./6_TROUBLESHOOTING_AND_RESOURCES.md){: .btn .btn-primary} | 
+[Volver Arriba](#top){: .btn .btn-primary}

--- a/languages/es/guides/6_TROUBLESHOOTING_AND_RESOURCES.md
+++ b/languages/es/guides/6_TROUBLESHOOTING_AND_RESOURCES.md
@@ -1,0 +1,86 @@
+# Guía 6: Resolución de Problemas y Recursos
+
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Paso Anterior: Empaquetado y Compartición](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+
+Esta guía proporciona soluciones para los problemas comunes que surgen durante el proceso de preparación de datos, entrenamiento e inferencia de TTS, junto con una lista de herramientas y recursos útiles.
+
+---
+
+## 8. Resolución de Problemas Comunes
+
+Consulta esta tabla cuando encuentres problemas. Los problemas suelen tener su origen en la calidad de los datos o en los ajustes de configuración.
+
+| Categoría del Problema         | Problema Específico                                      | Causas Posibles y Soluciones                                                                                                                                                              | Guía(s) Relevante(s)                                                                 |
+| :----------------------- | :-------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
+| **Preparación de Datos**   | Errores de script durante la segmentación/normalización       | Rutas de archivo incorrectas; formato de audio inicialmente no soportado; dependencias faltantes (`ffmpeg`, `pydub`); audio extremadamente ruidoso/silencioso que confunde la detección de silencio. **Comprueba las rutas del script, instala las dependencias, ajusta los parámetros de silencio.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md)                                  |
+|                          | La generación del manifest omite muchos archivos                | Nombres de archivo no coincidentes entre el audio y las transcripciones; archivos de transcripción vacíos; rutas incorrectas especificadas en el script; codificación no UTF-8 en los archivos de texto. **Verifica los nombres, comprueba las rutas, asegúrate de que los archivos de texto tengan contenido y codificación UTF-8.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md)                                  |
+| **Configuración del Entrenamiento**     | `pip install` falla                               | Librerías del sistema faltantes (p. ej., `libsndfile-dev`); versión de Python incompatible; problemas de red; conflictos entre paquetes. **Lee los mensajes de error con atención, instala las librerías del sistema, usa un entorno virtual, consulta la documentación del framework para los prerrequisitos.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md)                                    |
+|                          | PyTorch `cuda is not available`                   | Versión de PyTorch incorrecta instalada (solo CPU); versión incompatible del driver de NVIDIA/toolkit de CUDA; GPU no detectada por el SO. **Reinstala PyTorch con la versión correcta de CUDA desde el sitio oficial, actualiza los drivers.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md)                                    |
+| **Ejecución del Entrenamiento** | Error CUDA Out-of-Memory (OOM) al inicio/durante el entrenamiento | `batch_size` demasiado grande para la VRAM de la GPU; arquitectura del modelo demasiado compleja; fuga de memoria (memory leak) en el framework/código personalizado. **Reduce el `batch_size` en la configuración; habilita la Precisión Mixta Automática (AMP/FP16) si está disponible; comprueba si hay actualizaciones del framework.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | El Training Loss es `NaN` o diverge (explota)     | Tasa de aprendizaje demasiado alta; gradientes inestables; batch de datos defectuoso (p. ej., audio/texto corrupto); problemas de precisión numérica. **Reduce la tasa de aprendizaje; comprueba la calidad de los datos; usa recorte de gradiente (gradient clipping) (a menudo habilitado por defecto); prueba FP32 si usas AMP/FP16.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | El Training Loss se estanca (no disminuye)        | Tasa de aprendizaje demasiado baja; mala calidad/variedad de datos; modelo atascado en un mínimo local; configuración incorrecta del modelo. **Aumenta ligeramente la tasa de aprendizaje; mejora/aumenta los datos; comprueba la configuración (esp. los parámetros de audio); prueba un optimizador diferente.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | El Validation Loss aumenta mientras el Training Loss disminuye (Overfitting) | El modelo memoriza los datos de entrenamiento; conjunto de validación insuficiente/no representativo; entrenamiento durante demasiado tiempo. **Detén el entrenamiento de forma temprana (basándote en el mejor val loss); añade más datos de entrenamiento diversos; usa regularización (weight decay, dropout - comprueba la configuración); mejora el conjunto de validación.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+| **Calidad de Inferencia**  | La salida suena robótica/monótona                   | Entrenamiento insuficiente; mala prosodia en los datos de entrenamiento; limitaciones de la arquitectura del modelo; problemas de normalización del texto. **Entrena durante más tiempo; mejora la variedad/calidad de los datos; prueba una arquitectura de modelo diferente; asegúrate de que el texto esté bien puntuado/normalizado.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+|                          | La salida es ruidosa/distorsionada/ininteligible            | Mala calidad de los datos (ruido incorporado); el modelo no convergió; desajuste entre la configuración de entrenamiento y la configuración/checkpoint de inferencia; sampling rate incorrecto usado en la inferencia. **Limpia rigurosamente los datos de entrenamiento; entrena durante más tiempo; asegura una coincidencia EXACTA de configuración/checkpoint; verifica los parámetros de audio.** | Todas las Guías                                                                        |
+|                          | La salida suena como el locutor incorrecto (fine-tuning) | Modelo preentrenado no cargado correctamente; tasa de aprendizaje demasiado alta inicialmente; datos/pasos de fine-tuning insuficientes; desajuste del speaker ID. **Verifica `pretrained_model_path` e `ignore_layers` en la configuración; usa una LR más baja para el fine-tuning; entrena durante más tiempo; comprueba el speaker ID.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+|                          | La inferencia se corta antes de tiempo o habla demasiado rápido/lento  | Limitación del modelo (predicción de duración); ajuste de inferencia que limita la longitud máxima de salida; parámetro de length scale/velocidad incorrecto. **Consulta la documentación del framework para los ajustes de pasos máximos del decodificador / longitud máxima; ajusta los parámetros de control de velocidad.** | [4_INFERENCE.md](./4_INFERENCE.md)                                                |
+| **Uso del Modelo**        | No se puede cargar el archivo de checkpoint                       | Descarga/archivo corrupto; uso de un checkpoint con una versión del framework o archivo de configuración incompatible; ruta de archivo incorrecta. **Vuelve a descargar/verifica la integridad del archivo; usa la configuración correcta; asegúrate de que la versión del framework coincida con la usada para el entrenamiento; comprueba la ruta.** | [5_PACKAGING_AND_SHARING.md](./5_PACKAGING_AND_SHARING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+
+---
+
+## 10. Recursos y Herramientas Útiles
+
+Esta lista incluye software, librerías y comunidades útiles para proyectos de TTS.
+
+### Procesamiento y Análisis de Audio:
+
+*   **[Audacity](https://www.audacityteam.org/):** Editor de audio gratuito, de código abierto y multiplataforma. Excelente para la inspección manual, limpieza, etiquetado y procesamiento básico de archivos de audio.
+*   **[FFmpeg](https://ffmpeg.org/):** La herramienta de línea de comandos multiusos (navaja suiza) para conversión de audio/vídeo, remuestreo, manipulación de canales, cambios de formato y mucho más. Esencial para automatizar operaciones por lotes.
+*   **[SoX (Sound eXchange Compiled)](http://sox.sourceforge.net/) o [Sox - Source Code](https://codeberg.org/sox_ng/sox_ng/):** Utilidad de línea de comandos para el procesamiento de audio. Útil para efectos, conversión de formato y obtención de información del audio (comando `soxi`).
+*   **[pydub](https://github.com/jiaaro/pydub):** Librería de Python para una fácil manipulación de audio (corte, conversión de formato, ajuste de volumen, detección de silencio). Usa el backend de ffmpeg/libav.
+*   **[librosa](https://librosa.org/doc/latest/index.html):** Librería de Python para análisis avanzado de audio, extracción de características (como los espectrogramas mel) y visualización. A menudo usada internamente por los frameworks de TTS.
+*   **[soundfile](https://python-soundfile.readthedocs.io/en/latest/):** Librería de Python para leer/escribir archivos de audio, basada en libsndfile. Soporta muchos formatos.
+*   **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm):** Librería de Python para la normalización de sonoridad (LUFS), generalmente preferida sobre la simple normalización de pico para una consistencia percibida.
+
+### Transcripción (ASR):
+
+*   **[OpenAI Whisper](https://github.com/openai/whisper):** Modelo ASR de código abierto y alta calidad, soporta muchos idiomas. Buena base de referencia, pero la puntuación a menudo necesita revisión. Puede ejecutarse localmente (se recomienda GPU) o vía API. Existen varias implementaciones de la comunidad.
+*   **[Modelos Google Gemini (vía API/AI Studio)](https://ai.google.dev/):** Modelos capaces para la transcripción, a menudo rinden bien con audio claro, potencialmente mejor en segmentos previamente segmentados. Comprueba la API/Studio para conocer las capacidades actuales y los precios/niveles gratuitos.
+*   **Servicios de ASR en la Nube:**
+    *   [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text)
+    *   [AWS Transcribe](https://aws.amazon.com/transcribe/)
+    *   [Azure Speech Service](https://azure.microsoft.com/en-us/products/cognitive-services/speech-to-text/)
+    *   *A menudo fiables, de pago por uso, pueden tener cuotas gratuitas iniciales.*
+*   **[Hugging Face Transformers - Modelos ASR](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition):** Hub para muchos modelos ASR preentrenados, incluyendo versiones con fine-tuning de Whisper y otros. Explora modelos con fine-tuning para idiomas específicos o mejora de la puntuación.
+*   **[ElevenLabs Speech To Text (Scribe)](https://elevenlabs.io/speech-to-text):** *Servicio Comercial.* Conocido por una precisión muy alta tanto en la transcripción como en la puntuación, pero es un servicio de pago y puede ser relativamente caro en comparación con otros. Vale la pena considerarlo si el presupuesto lo permite y se requiere la máxima precisión lista para usar.
+
+### Frameworks y Bases de Código de TTS (Ejemplos - Busca forks/sucesores activos):
+
+*   **[StyleTTS2 (Repo de Investigación)](https://github.com/yl4579/StyleTTS2):** Trabajo influyente sobre el control de estilo. Busca forks mantenidos activamente que hayan implementado pipelines de entrenamiento/inferencia.
+*   **[VITS (Repo de Investigación)](https://github.com/jaywalnut310/vits):** Arquitectura popular de extremo a extremo. Existen muchos forks e implementaciones.
+*   **[Coqui TTS (Archivado)](https://github.com/coqui-ai/TTS):** Fue una librería muy popular y completa. Aunque está archivada, su base de código y sus conceptos siguen siendo influyentes. Es posible que existan muchos forks activos.
+*   **[ESPnet](https://github.com/espnet/espnet):** Kit de herramientas de procesamiento de voz de extremo a extremo, que incluye recetas de TTS para varios modelos. Más orientado a la investigación.
+*   **Busca en GitHub:** Usa palabras clave como "TTS", "VITS training", "StyleTTS2 training", "PyTorch TTS" para encontrar proyectos actuales.
+
+### Entorno de Python y Deep Learning:
+
+*   **[Python](https://www.python.org/):** El lenguaje de programación central.
+*   **[PyTorch](https://pytorch.org/):** La principal librería de deep learning usada por la mayoría de los frameworks modernos de TTS.
+*   **[TensorBoard](https://www.tensorflow.org/tensorboard):** Esencial para visualizar el progreso del entrenamiento (también funciona con PyTorch).
+*   **[pip](https://pip.pypa.io/en/stable/) / [uv](https://github.com/astral-sh/uv):** Instaladores de paquetes de Python. `uv` es una alternativa más nueva y a menudo mucho más rápida.
+*   **[conda](https://docs.conda.io/en/latest/) / [venv](https://docs.python.org/3/library/venv.html):** Herramientas para crear entornos de Python aislados.
+*   **[Git](https://git-scm.com/):** Sistema de control de versiones, esencial para clonar repositorios y gestionar código.
+*   **[Hugging Face Hub](https://huggingface.co/):** Plataforma para compartir modelos (incluyendo TTS), datasets y código.
+
+### Comunidades:
+
+*   **GitHub Discussions/Issues de los Frameworks de TTS:** Consulta el repositorio específico que estés usando para preguntas y respuestas de la comunidad.
+*   **Servidores de Discord:** Muchas comunidades de IA/ML (como LAION, EleutherAI, servidores de frameworks específicos) tienen canales dedicados a TTS.
+*   **Reddit:** Subreddits como r/SpeechSynthesis, r/MachineLearning.
+
+---
+
+Esto concluye la serie principal de guías. Recuerda que construir buenos modelos TTS a menudo implica iteración: revisar la preparación de datos o ajustar los parámetros de entrenamiento según los resultados es una práctica común. ¡Mucha suerte!
+
+---
+**Navegación:** [README Principal]({{ site.baseurl }}/languages/es/){: .btn .btn-primary} | [Paso Anterior: Empaquetado y Compartición](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | [Volver Arriba](#top){: .btn .btn-primary}

--- a/languages/fr/README.md
+++ b/languages/fr/README.md
@@ -1,31 +1,144 @@
-# Guide Universel pour l'Entraînement de Modèles TTS et la Préparation de Jeux de Données
+# Guide universel d'entraînement de modèles TTS et de préparation de jeux de données
 
-## Langues Disponibles
+## Langues disponibles
 
 - [English](../../README.md) (Original)
-- [Español](../es/README.md) (À venir)
+- [Español](../es/README.md)
 - **Français** (Actuel)
-- [Български](/languages/bg/README.md) (Translated by AcTePuKc)
+- [Italiano](../it/README.md)
+- [Български](../bg/README.md)
 
-*Vous souhaitez contribuer à une traduction ? Consultez le [Guide de Traduction](../../README.md#translation-guide).*
+*Vous souhaitez contribuer à une traduction ? Consultez le [Guide de traduction](../../README.md#translation-guide) ci-dessous.*
 
 ## Introduction
 
-Bienvenue ! Ce guide complet fournit un processus universel pour préparer vos propres jeux de données vocales et entraîner un modèle Text-to-Speech (TTS) personnalisé. Que vous ayez un petit jeu de données (par exemple, 10 heures) ou un plus grand (plus de 100 heures), ces étapes vous aideront à organiser correctement vos données et à naviguer dans le processus d'entraînement pour la plupart des frameworks TTS modernes.
+Bienvenue ! Ce guide complet propose un processus universel pour préparer vos propres jeux de données vocaux et entraîner un modèle de synthèse vocale (TTS, Text-to-Speech) personnalisé. Que vous disposiez d'un petit jeu de données (par exemple, 10 heures) ou d'un plus volumineux (100 heures et plus), ces étapes vous aideront à organiser correctement vos données et à mener à bien le processus d'entraînement pour la plupart des frameworks TTS modernes.
 
-**Objectif :** Vous permettre d'affiner ou d'entraîner un modèle TTS sur une voix ou une langue spécifique en utilisant vos propres paires audio-texte.
+**Objectif :** Vous donner les moyens d'effectuer un fine-tuning ou d'entraîner un modèle TTS sur une voix ou une langue spécifique à partir de vos propres paires audio-texte.
 
 **Ce que couvre ce guide :**
-Ce guide est divisé en plusieurs parties, couvrant l'ensemble du flux de travail, de la planification à l'utilisation de votre modèle entraîné :
+Ce guide est divisé en plusieurs parties, couvrant l'intégralité du flux de travail, de la planification à l'utilisation de votre modèle entraîné :
 
-1.  **Planification :** Considérations initiales avant de commencer votre projet.
-2.  **Préparation des données :** Acquisition, traitement et structuration des données audio et texte.
+1.  **Planification :** Considérations initiales avant de démarrer votre projet.
+2.  **Préparation des données :** Acquisition, traitement et structuration des données audio et textuelles.
 3.  **Configuration de l'entraînement :** Préparation de votre environnement et configuration des paramètres d'entraînement.
-4.  **Entraînement du modèle :** Lancement, surveillance et ajustement fin du modèle TTS.
-5.  **Inférence :** Utilisation de votre modèle entraîné pour synthétiser la parole.
-6.  **Empaquetage et partage :** Organisation et documentation de votre modèle pour une utilisation future ou une distribution.
+4.  **Entraînement du modèle :** Lancement, suivi et fine-tuning du modèle TTS.
+5.  **Inférence :** Utilisation de votre modèle entraîné pour synthétiser de la parole.
+6.  **Packaging et partage :** Organisation et documentation de votre modèle pour une utilisation future ou une distribution.
 7.  **Dépannage et ressources :** Problèmes courants et outils utiles.
 
 ---
 
-*Note : Ceci est une traduction en cours. Les sections restantes seront traduites prochainement.*
+## 0. Avant de commencer : planifier votre jeu de données
+
+Avant de collecter des données, prenez en compte ces points cruciaux pour vous assurer que votre projet est bien défini et réalisable :
+
+1.  **Locuteur :** S'agira-t-il d'un seul locuteur ou de plusieurs locuteurs ? Les jeux de données à locuteur unique sont plus simples pour débuter avec un fine-tuning ou un entraînement initial. Les modèles multi-locuteurs nécessitent un équilibrage soigneux des données et une gestion des identifiants de locuteur (speaker ID).
+2.  **Source des données :** Où obtiendrez-vous l'audio ? (Livres audio, podcasts, archives radiophoniques, données vocales enregistrées professionnellement, vos propres enregistrements). **Point crucial : assurez-vous de disposer des droits ou des licences nécessaires pour utiliser ces données afin d'entraîner des modèles.**
+3.  **Qualité audio :** Visez la meilleure qualité possible. Privilégiez des enregistrements propres avec un minimum de bruit de fond, de réverbération, de musique ou de paroles superposées. La cohérence des conditions d'enregistrement est très bénéfique.
+4.  **Langue et domaine :** Quelle(s) langue(s) le modèle parlera-t-il ? Quel est le style de parole ou le domaine (par exemple, narration, conversationnel, lecture de bulletins d'information) ? Le modèle sera plus performant sur des textes similaires à ses données d'entraînement.
+5.  **Volume de données cible :** Quelle quantité de données prévoyez-vous de collecter ou d'utiliser ?
+    *   **~1 à 5 heures :** Peut suffire pour un *clonage* vocal de base avec un modèle pré-entraîné performant, mais la qualité peut être limitée.
+    *   **~5 à 20 heures :** Généralement considéré comme le minimum pour un *fine-tuning* correct d'une voix spécifique sur un modèle pré-entraîné.
+    *   **50 à 100 heures et plus :** Préférable pour entraîner des modèles robustes ou des modèles dépendant moins des poids pré-entraînés, en particulier pour les langues moins courantes.
+    *   **1000 heures et plus :** Nécessaire pour entraîner des modèles polyvalents de haute qualité, en grande partie à partir de zéro.
+6.  **Sampling rate :** Décidez tôt d'un sampling rate (fréquence d'échantillonnage) cible (par exemple, 16000 Hz, 22050 Hz, 44100 Hz, 48000 Hz). Des fréquences plus élevées capturent davantage de détails mais nécessitent plus de stockage et de calcul. **Toutes vos données d'entraînement DOIVENT utiliser de manière cohérente la fréquence choisie.** 22050 Hz constitue un compromis courant pour de nombreux modèles TTS.
+
+---
+
+## Vue d'ensemble du processus et navigation
+
+Ce guide est décomposé en modules ciblés. Suivez les liens ci-dessous pour obtenir des étapes détaillées sur chaque phase :
+
+1.  **➡️ [Préparation des données](./guides/1_DATA_PREPARATION.md)**
+    *   Couvre l'acquisition, le nettoyage, la segmentation, la normalisation de l'audio, la transcription du texte et la création des fichiers manifest nécessaires à l'entraînement. Comprend la checklist cruciale de qualité des données.
+
+2.  **➡️ [Configuration de l'entraînement](./guides/2_TRAINING_SETUP.md)**
+    *   Vous guide dans la configuration de votre environnement Python, l'installation des dépendances (comme PyTorch avec CUDA), le choix d'un framework TTS et la configuration des paramètres d'entraînement dans votre fichier de configuration.
+
+3.  **➡️ [Entraînement du modèle](./guides/3_MODEL_TRAINING.md)**
+    *   Explique comment lancer le script d'entraînement, suivre sa progression (loss, validation), reprendre un entraînement interrompu et fournit des conseils spécifiques pour le fine-tuning de modèles existants.
+
+4.  **➡️ [Inférence](./guides/4_INFERENCE.md)**
+    *   Détaille comment utiliser le checkpoint de votre modèle entraîné pour synthétiser de la parole à partir d'un nouveau texte, y compris le traitement d'une phrase unique, le traitement par lots et les considérations multi-locuteurs.
+
+5.  **➡️ [Packaging et partage](./guides/5_PACKAGING_AND_SHARING.md)**
+    *   Fournit les bonnes pratiques pour organiser les fichiers de votre modèle entraîné (checkpoints, configs, échantillons), les documenter avec un README, les versionner et les préparer pour le partage ou l'archivage.
+
+6.  **➡️ [Dépannage et ressources](./guides/6_TROUBLESHOOTING_AND_RESOURCES.md)** 
+    *   Propose des solutions aux problèmes courants rencontrés lors de l'entraînement et de l'inférence, et répertorie des outils, bibliothèques et communautés externes utiles.
+
+---
+
+## Conclusion
+
+En suivant ces guides, vous acquerrez une compréhension complète du flux de travail pour préparer des données et entraîner vos propres modèles de synthèse vocale. N'oubliez pas qu'une préparation méticuleuse des données est le fondement d'une voix de haute qualité, et que le processus d'entraînement implique souvent un raffinement itératif.
+
+Maintenant, passez à la section pertinente en fonction de l'étape où vous en êtes dans le cycle de vie de votre projet. Bonne chance pour la création de vos voix personnalisées ! 🚀
+
+## Contribuer 
+
+Les contributions visant à améliorer ce guide sont les bienvenues ! Que vous trouviez des fautes de frappe, des inexactitudes, que vous ayez des suggestions pour des explications plus claires, que vous souhaitiez ajouter des informations sur des outils ou frameworks spécifiques, ou que vous ayez des idées pour de nouvelles sections, votre contribution est précieuse.
+
+N'hésitez pas à :
+
+*   **Ouvrir une Issue :** Pour signaler des erreurs, suggérer des améliorations ou discuter de changements potentiels.
+*   **Soumettre une Pull Request :** Pour des corrections ou ajouts concrets. Veuillez essayer de vous assurer que vos modifications sont claires et s'alignent avec la structure et le ton général du guide.
+
+Nous apprécions tout effort visant à rendre ce guide plus précis, complet et utile pour la communauté !
+
+## Glossaire des termes techniques
+
+Ce glossaire explique les principaux termes techniques utilisés tout au long des guides afin d'aider les débutants à comprendre la terminologie :
+
+- **ASR (Automatic Speech Recognition)** : Technologie qui convertit le langage parlé en texte écrit ; utilisée pour transcrire les données audio (reconnaissance automatique de la parole).
+- **Batch Size** : Le nombre d'exemples d'entraînement traités ensemble lors d'une passe avant/arrière (forward/backward) ; affecte la vitesse d'entraînement et l'utilisation de la mémoire (taille de lot).
+- **Checkpoint** : Un instantané sauvegardé des poids d'un modèle pendant ou après l'entraînement, vous permettant de reprendre l'entraînement ou d'utiliser le modèle pour l'inférence.
+- **CUDA** : La plateforme de calcul parallèle de NVIDIA qui permet l'accélération GPU pour les tâches de deep learning.
+- **dBFS (Decibels relative to Full Scale)** : Une unité de mesure des niveaux audio dans les systèmes numériques, où 0 dBFS représente le niveau maximal possible (décibels par rapport à la pleine échelle).
+- **Diffusion Models** : Une classe de modèles génératifs qui ajoutent progressivement puis suppriment du bruit des données ; certains systèmes TTS récents utilisent cette approche (modèles de diffusion).
+- **FFT (Fast Fourier Transform)** : Un algorithme qui convertit les signaux du domaine temporel en représentations du domaine fréquentiel ; fondamental pour le traitement audio (transformée de Fourier rapide).
+- **Fine-tuning** : Le processus consistant à prendre un modèle pré-entraîné et à poursuivre son entraînement sur un jeu de données plus petit et spécifique afin de l'adapter à une nouvelle voix ou langue.
+- **LUFS (Loudness Units relative to Full Scale)** : Une mesure standardisée de la sonie perçue, plus représentative de l'audition humaine que les mesures de crête.
+- **Manifest File** : Un fichier texte qui répertorie les fichiers audio et leurs transcriptions correspondantes, utilisé pour indiquer au script d'entraînement où trouver les données (fichier manifest).
+- **Mel Spectrogram** : Une représentation visuelle de l'audio qui approxime la perception auditive humaine en utilisant l'échelle mel ; couramment utilisée comme représentation intermédiaire dans les systèmes TTS (spectrogramme mel).
+- **Overfitting** : Lorsqu'un modèle apprend trop bien les données d'entraînement, y compris leur bruit et leurs valeurs aberrantes, ce qui entraîne de mauvaises performances sur de nouvelles données (surapprentissage).
+- **Sampling Rate** : Le nombre d'échantillons audio par seconde (mesuré en Hz) ; des fréquences plus élevées capturent davantage de détails audio mais nécessitent plus de stockage et de puissance de traitement (fréquence d'échantillonnage).
+- **STFT (Short-Time Fourier Transform)** : Une technique qui détermine le contenu fréquentiel de sections locales d'un signal au fur et à mesure qu'il évolue dans le temps (transformée de Fourier à court terme).
+- **TTS (Text-to-Speech)** : Technologie qui convertit le texte écrit en sortie vocale parlée (synthèse vocale).
+- **Validation Loss** : Une métrique qui mesure l'erreur d'un modèle sur un jeu de données de validation (données non utilisées pour l'entraînement) ; aide à détecter l'overfitting (perte de validation).
+- **VRAM (Video RAM)** : La mémoire d'une carte graphique ; les modèles de deep learning et leurs calculs intermédiaires y sont stockés pendant l'entraînement.
+- **Vocoder** : Un composant de certains systèmes TTS qui convertit les caractéristiques acoustiques (comme les spectrogrammes mel) en formes d'onde (audio réel).
+
+## Guide de traduction
+
+Nous accueillons favorablement les traductions de ce guide afin de le rendre accessible à un public plus large. Si vous souhaitez contribuer à une traduction, veuillez suivre ces étapes :
+
+1. **Forkez le dépôt** vers votre propre compte GitHub
+2. **Créez la structure de répertoires nécessaire** pour votre langue :
+   ```
+   languages/[language_code]/
+   ├── README.md
+   └── guides/
+       ├── 1_DATA_PREPARATION.md
+       ├── 2_TRAINING_SETUP.md
+       └── ... (tous les fichiers de guide)
+   ```
+   Où `[language_code]` est le code à deux lettres ISO 639-1 de votre langue (par exemple, `es` pour l'espagnol)
+
+3. **Traduisez le contenu** en commençant par le README.md, puis les fichiers de guide individuels
+   - Conservez la même structure de fichiers et le même formatage Markdown
+   - Laissez tous les exemples de code inchangés (ils doivent rester en anglais)
+   - Traduisez tout le texte explicatif, les en-têtes et les commentaires
+
+4. **Mettez à jour les liens de navigation** pour qu'ils pointent vers les bons fichiers dans le répertoire de votre langue
+
+5. **Soumettez une Pull Request** avec votre traduction
+
+**Remarques importantes pour les traducteurs :**
+- Les termes techniques peuvent être difficiles à traduire. En cas de doute, vous pouvez conserver le terme anglais suivi d'une brève explication dans votre langue.
+- Essayez de conserver le même ton et le même niveau de détail technique que l'original.
+- Si vous trouvez des erreurs ou des points à améliorer dans le contenu anglais original lors de la traduction, veuillez ouvrir une issue distincte pour les traiter.
+
+## [Licence](../../LICENCE.md)
+Le contenu de ce guide est sous licence [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/). Vous êtes libre de partager et d'adapter le contenu tant que vous attribuez le crédit approprié. Le contenu est également protégé par le droit d'auteur 2025 AcTePuKc et toute nouvelle contribution sera soumise à la même licence.

--- a/languages/fr/guides/1_DATA_PREPARATION.md
+++ b/languages/fr/guides/1_DATA_PREPARATION.md
@@ -1,0 +1,573 @@
+# Guide 1 : Préparation des données pour l'entraînement TTS
+
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape suivante : Configuration de l'entraînement](./2_TRAINING_SETUP.md){: .btn .btn-primary} | 
+
+Ce guide couvre la première phase critique de tout projet TTS : la préparation de données audio et textuelles de haute qualité et correctement formatées. La qualité de votre jeu de données a un impact direct sur la qualité de votre modèle TTS final.
+
+---
+
+## 1. Étapes de préparation du jeu de données
+
+Suivez ces étapes de manière systématique pour transformer l'audio brut en un jeu de données prêt pour l'entraînement.
+
+### 1.1. Acquisition audio et traitement initial
+
+-   **Rassembler l'audio :** Collectez vos fichiers audio bruts (les formats courants incluent WAV, MP3, FLAC, OGG, M4A). Assurez-vous de disposer des droits d'utilisation de cet audio.
+-   **Convertir en WAV :** La plupart des frameworks TTS attendent le format WAV. Utilisez des outils comme `ffmpeg` ou des bibliothèques audio (`pydub`, `soundfile`) pour convertir votre audio. Visez un encodage WAV standard comme PCM 16 bits.
+    ```bash
+    # Exemple utilisant ffmpeg pour convertir un MP3 en WAV
+    ffmpeg -i input_audio.mp3 output_audio.wav
+    ```
+-   **Standardiser les canaux (Mono) :** Les modèles TTS s'entraînent généralement sur de l'audio mono (un seul canal). Convertissez les pistes stéréo en mono.
+    ```bash
+    # Exemple utilisant ffmpeg pour convertir un WAV stéréo en WAV mono
+    ffmpeg -i stereo_input.wav -ac 1 mono_output.wav
+    ```
+    *   `-ac 1` : Définit le nombre de canaux audio à 1.
+-   **Rééchantillonner l'audio :** Assurez-vous que tous les fichiers audio ont **exactement le même sampling rate**. Choisissez votre fréquence cible en fonction des objectifs de votre projet et de la compatibilité du framework (par exemple, 16000 Hz, 22050 Hz, 48000 Hz). 22050 Hz est courant pour de nombreux modèles.
+    ```bash
+    # Exemple utilisant ffmpeg pour rééchantillonner à 22050 Hz
+    ffmpeg -i input.wav -ar 22050 resampled_output.wav
+    ```
+    *   `-ar 22050` : Définit le sampling rate audio (échantillons par seconde).
+
+### 1.2 Nettoyage audio avancé (Suppression du bruit/de la musique) - *Optionnel mais recommandé*
+
+-   **Objectif :** Supprimer les sons de fond indésirables comme le bruit (ronflement, sifflement, ventilateurs), la musique, la réverbération ou d'autres voix interférentes de votre audio source, afin d'isoler autant que possible la voix du locuteur cible. Cette étape est cruciale si votre audio source n'est pas de qualité studio.
+-   **Pourquoi ?** Les modèles TTS apprennent à partir de l'audio qu'on leur fournit. Si l'audio contient du bruit de fond ou de la musique, la voix TTS résultante héritera probablement de ces caractéristiques, sonnant bruyante ou « boueuse ». Un audio plus propre conduit à une voix TTS plus propre.
+
+-   **Outils et techniques :**
+    *   **Outils de séparation de sources par IA (Recommandés pour la musique/voix) :** Ces outils utilisent des modèles d'IA pour séparer l'audio en différentes pistes (voix, musique, batterie, basse, autres).
+        *   **[Ultimate Vocal Remover (UVR)](https://ultimatevocalremover.com/)** : Une application GUI populaire, gratuite et open source qui donne accès à divers modèles de séparation par IA à la pointe de la technologie. Elle est excellente pour supprimer la musique de fond ou isoler les dialogues.
+            *   **Modèles (comme ceux mentionnés) :** UVR vous permet d'utiliser différents modèles d'IA. `MDX-Inst-HQ3` est l'un de ces modèles souvent efficace pour séparer les voix des instruments (d'où « Inst »). D'autres modèles MDX, les modèles Demucs (comme `htdemucs`) et potentiellement des modèles comme Mel-Roformer (s'ils sont intégrés ou disponibles de manière autonome) sont conçus pour des tâches similaires, chacun avec des forces et des faiblesses légèrement différentes. L'expérimentation est essentielle. Choisissez des modèles axés sur l'**isolation vocale**.
+        *   **Autres outils :** Des services en ligne (par exemple, Lalal.ai) ou d'autres logiciels autonomes peuvent utiliser des modèles sous-jacents similaires (souvent des variantes de Demucs ou Spleeter).
+    *   **Outils traditionnels de réduction du bruit :** Souvent présents dans les stations de travail audio numériques (DAW) ou les éditeurs audio.
+        *   **[Audacity](https://www.audacityteam.org/) :** Contient des effets intégrés de réduction du bruit (nécessite d'échantillonner un profil de bruit). Peut être efficace contre le bruit de fond constant (comme le sifflement ou le ronflement).
+        *   **Plugins commerciaux (par exemple, Izotope RX, Waves Clarity) :** Offrent des outils plus sophistiqués d'isolation du bruit, de la réverbération et de la voix alimentés par l'IA, mais sont payants.
+    *   **Édition spectrale :** Suppression manuelle des sons indésirables dans un éditeur spectral (comme Adobe Audition, Izotope RX, Acon Digital Acoustica). Puissant mais très chronophage.
+
+-   **Considérations relatives au flux de travail :**
+    *   **Quand l'appliquer :** Il est généralement recommandé d'appliquer le nettoyage à vos **fichiers audio plus longs *avant* le découpage (Étape 1.3 ci-dessous)**. Cela permet aux modèles d'IA de travailler avec plus de contexte et peut être plus efficace que de traiter des milliers de petits segments. Cependant, si le nettoyage introduit trop d'artefacts sur les fichiers longs, vous pourriez essayer de nettoyer individuellement les segments problématiques ultérieurement.
+    *   **Processus :**
+        1.  Chargez votre fichier WAV standardisé (issu de l'Étape 1.1) dans l'outil choisi (par exemple, UVR).
+        2.  Sélectionnez un modèle d'isolation vocale approprié (par exemple, un modèle vocal MDX ou Demucs).
+        3.  Traitez l'audio pour générer une piste « voix uniquement ».
+        4.  **Écoutez attentivement :** Évaluez de manière critique la piste vocale séparée. Vérifiez :
+            *   **Les artefacts :** La séparation par IA peut parfois introduire des sons « aqueux », des glitches ou des parties de la voix supprimées par erreur.
+            *   **Le bruit/la musique résiduels :** Avec quelle efficacité le son indésirable a-t-il été supprimé ?
+        5.  **Itérez :** Vous devrez peut-être essayer différents modèles, ajuster les paramètres au sein de l'outil, ou même appliquer une seconde passe de réduction du bruit (par exemple, en utilisant la réduction du bruit d'Audacity sur les voix séparées par l'IA) pour obtenir les meilleurs résultats.
+    *   **Enregistrer la sortie :** Enregistrez la piste vocale nettoyée sous forme d'un nouveau fichier WAV (par exemple, `original_file_cleaned.wav`). Utilisez ces fichiers nettoyés comme entrée pour l'étape *suivante* (Découpage).
+
+-   **Mises en garde :**
+    *   **Des artefacts sont possibles :** Un nettoyage agressif peut dégrader le naturel de la voix cible. Visez un équilibre entre la suppression du bruit et la préservation de la qualité vocale.
+    *   **Coût de calcul :** Les modèles de séparation par IA peuvent être gourmands en calcul et prendre un temps considérable, en particulier sur les fichiers audio longs et sans GPU puissant.
+
+
+### 1.3. Découpage audio (Division en segments)
+
+-   **Objectif :** Diviser les longs fichiers audio (comme les chapitres d'un livre audio ou les épisodes de podcast) en segments plus courts et gérables. La durée idéale d'un segment se situe généralement entre **2 et 15 secondes**.
+-   **Pourquoi découper ?**
+    *   Aligne la durée audio sur les longueurs de phrases typiques.
+    *   Rend la transcription réalisable (transcrire des fichiers de plusieurs heures est difficile).
+    *   Aide à gérer la mémoire pendant l'entraînement.
+    *   Permet de filtrer les segments inadaptés (par exemple, silence pur, bruit, musique).
+-   **Méthode :** Utilisez des outils qui détectent le silence pour diviser l'audio. `pydub` est une bibliothèque Python populaire pour cela.
+
+    ```python
+    # Exemple utilisant pydub pour la division basée sur le silence
+    from pydub import AudioSegment
+    from pydub.silence import split_on_silence
+    import os
+
+    input_file = "resampled_mono_audio.wav" # Utilisez la sortie de l'étape 1.1
+    output_dir = "audio_chunks"             # Créez ce répertoire
+    os.makedirs(output_dir, exist_ok=True)
+
+    print(f"Loading audio file: {input_file}")
+    sound = AudioSegment.from_wav(input_file)
+    print("Audio loaded. Splitting based on silence...")
+
+    chunks = split_on_silence(
+        sound,
+        min_silence_len=500,    # Durée minimale de silence en millisecondes pour déclencher une division. À ajuster selon les besoins.
+        silence_thresh=-40,     # Seuil de silence en dBFS (décibels par rapport à la pleine échelle). Des valeurs plus basses (par ex. -50) détectent des silences plus faibles. À ajuster selon le niveau de bruit de fond de votre audio.
+        keep_silence=200        # Optionnel : Quantité de silence (en ms) à laisser au début/à la fin de chaque segment. Aide à éviter les coupures abruptes.
+    )
+
+    print(f"Found {len(chunks)} potential chunks before duration filtering.")
+
+    # --- Filtrage et exportation ---
+    min_duration_sec = 2.0  # Durée minimale du segment en secondes
+    max_duration_sec = 15.0 # Durée maximale du segment en secondes
+    target_sr = 22050       # Assure que les segments conservent le bon sampling rate (pydub gère généralement cela)
+
+    exported_count = 0
+    for i, chunk in enumerate(chunks):
+        duration_sec = len(chunk) / 1000.0
+        if min_duration_sec <= duration_sec <= max_duration_sec:
+            # Assure que le segment utilise le sampling rate cible si nécessaire (pydub essaie de le préserver)
+            # chunk = chunk.set_frame_rate(target_sr) # Généralement inutile si la source était correctement échantillonnée
+            
+            chunk_filename = f"segment_{exported_count:05d}.wav" # Utilise un remplissage pour faciliter le tri
+            chunk_path = os.path.join(output_dir, chunk_filename)
+            
+            print(f"Exporting chunk {i} ({duration_sec:.2f}s) to {chunk_path}")
+            chunk.export(chunk_path, format="wav")
+            exported_count += 1
+        else:
+             print(f"Skipping chunk {i} due to duration: {duration_sec:.2f}s")
+
+
+    print(f"\nExported {exported_count} chunks meeting duration criteria ({min_duration_sec}-{max_duration_sec}s) to '{output_dir}'.")
+    ```
+-   **Vérification :** Écoutez un échantillon des segments générés. Les divisions sont-elles logiques ? La parole est-elle coupée ? Ajustez `min_silence_len` et `silence_thresh` et relancez si nécessaire. Une division manuelle ou un affinement des divisions dans un éditeur audio (comme Audacity) peut être nécessaire pour les audios délicats.
+
+### 1.4. Normalisation du volume
+
+-   **Objectif :** Garantir que tous les segments audio ont un niveau de volume cohérent. Cela empêche les segments trop faibles ou trop forts d'affecter l'entraînement de manière disproportionnée.
+-   **Méthodes :**
+    *   **Normalisation de crête (Peak) :** Ajuste l'audio pour que le point le plus fort atteigne un niveau spécifique (par exemple, -3.0 dBFS). Simple, mais ne garantit pas une sonie *perçue* cohérente.
+    *   **Normalisation de la sonie (LUFS) :** Ajuste l'audio pour atteindre un niveau de sonie perçue cible (par exemple, -23 LUFS est courant pour la diffusion). Généralement préférée car elle reflète mieux l'audition humaine. Nécessite des bibliothèques comme `pyloudnorm`.
+-   **Appliquer de manière cohérente :** Appliquez la méthode de normalisation choisie à *tous* les segments créés à l'étape précédente. Enregistrez les fichiers normalisés dans un **nouveau répertoire** (par exemple, `normalized_chunks`) pour conserver les originaux intacts.
+
+    ```python
+    # Exemple utilisant pydub pour la normalisation de CRÊTE (PEAK)
+    from pydub import AudioSegment
+    import os
+    import glob
+
+    input_chunk_dir = "audio_chunks"
+    output_norm_dir = "normalized_chunks"
+    os.makedirs(output_norm_dir, exist_ok=True)
+    
+    target_dBFS = -3.0 # Amplitude de crête cible
+
+    def match_target_amplitude(sound, target_dBFS):
+        change_in_dBFS = target_dBFS - sound.dBFS
+        return sound.apply_gain(change_in_dBFS)
+
+    print(f"Normalizing chunks from '{input_chunk_dir}' to '{output_norm_dir}' with target peak {target_dBFS} dBFS.")
+    
+    wav_files = glob.glob(os.path.join(input_chunk_dir, "*.wav"))
+    
+    for i, wav_file in enumerate(wav_files):
+        filename = os.path.basename(wav_file)
+        output_path = os.path.join(output_norm_dir, filename)
+        
+        try:
+            sound = AudioSegment.from_wav(wav_file)
+            # N'applique le gain que si le son n'est pas silencieux (dBFS n'est pas -inf)
+            if sound.dBFS > -float('inf'):
+              normalized_sound = match_target_amplitude(sound, target_dBFS)
+              normalized_sound.export(output_path, format="wav")
+            else:
+              print(f"Skipping silent file: {filename}")
+              # Optionnellement, copier les fichiers silencieux ou les gérer selon les besoins
+              # shutil.copy(wav_file, output_path) 
+            
+            if (i + 1) % 50 == 0: # Affiche la progression
+                 print(f"Processed {i+1}/{len(wav_files)} files...")
+                 
+        except Exception as e:
+            print(f"Error processing {filename}: {e}")
+
+    print(f"\nNormalization complete. Normalized files saved in '{output_norm_dir}'.")
+    ```
+    *   **Remarque :** Pour la normalisation LUFS, vous utiliseriez une bibliothèque comme `pyloudnorm`, en itérant sur les fichiers de manière similaire.
+
+### 1.5. Transcription : création des paires de texte
+
+-   **Objectif :** Obtenir une transcription textuelle précise pour *chaque segment audio normalisé*. Le texte doit représenter *exactement* ce qui est dit dans l'audio.
+-   **Méthodes :**
+    *   **Reconnaissance automatique de la parole (ASR) :** Idéale pour les grands jeux de données. Utilisez des modèles ASR de haute qualité.
+    *   **[OpenAI Whisper](https://github.com/openai/whisper) :** Excellente option multilingue et open source. S'exécute localement (GPU recommandé) ou via API. *Remarque : Bien que puissant pour la précision des mots, la ponctuation et la capitalisation de Whisper peuvent nécessiter une révision et une correction soigneuses lors de l'étape de nettoyage.* Divers modèles Whisper affinés par la communauté (souvent trouvés sur Hugging Face) peuvent offrir des améliorations.
+    *   **[Modèles Google Gemini](https://ai.google.dev/) (par exemple, via API ou AI Studio) :** Des modèles comme Gemini Pro ou Flash peuvent effectuer la transcription audio. Nécessitent souvent que l'audio soit dans des formats spécifiques et peuvent être plus performants sur des segments plus courts (s'alignant bien avec l'étape de pré-découpage). Vérifiez les offres API actuelles et les éventuels niveaux gratuits.
+    *   **Services cloud :** Google Cloud Speech-to-Text, AWS Transcribe, Azure Speech Service proposent des API robustes, souvent avec une tarification à l'usage et potentiellement des niveaux gratuits au départ.
+    *   **Autres modèles :** Explorez les [modèles Hugging Face](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition) pour d'autres modèles ASR open source ou affinés spécifiques à votre langue.
+    *   **Transcription manuelle :** La plus précise mais très chronophage. Convient aux jeux de données petits et de grande valeur ou pour *corriger les sorties ASR*.
+    *   **Transcriptions existantes :** Si votre audio source est accompagné de transcriptions alignées (par exemple, certains livres audio, archives de diffusion), vous aurez peut-être besoin de scripts pour les analyser et les aligner avec vos segments.
+-   **Format de sortie :** Créez un fichier `.txt` pour chaque fichier `.wav` correspondant dans votre répertoire `normalized_chunks`. Les noms de fichiers doivent correspondre exactement (par exemple, `normalized_chunks/segment_00001.wav` nécessite `transcripts/segment_00001.txt`).
+-   **Nettoyage et normalisation du texte :** **C'est crucial !**
+    *   **Supprimer le non-vocal :** Supprimez les horodatages (comme `[00:01:05]`), les étiquettes de locuteur (« SPEAKER A: », « John Doe: »), les balises d'événements sonores (`[laughter]`, `[music]`), les commentaires de transcription.
+    *   **Gérer les mots de remplissage :** Décidez de conserver ou de supprimer les mots de remplissage courants (« uh », « um », « ah »). Les conserver peut rendre le TTS plus naturel mais peut aussi introduire des hésitations indésirables. Les supprimer conduit à une parole plus propre et plus directe. La cohérence est essentielle.
+    *   **Ponctuation :** Assurez une ponctuation cohérente et appropriée. Les virgules, points et points d'interrogation aident le modèle à apprendre la prosodie. Évitez une ponctuation excessive ou non standard.
+    *   **Nombres, acronymes, symboles :** Développez-les en mots (par exemple, « 101 » -> « one hundred one », « USA » -> « U S A » ou « United States of America », « % » -> « percent »). La façon de les développer dépend de la manière dont vous souhaitez que le TTS les prononce. Créez un dictionnaire/jeu de règles de normalisation si nécessaire.
+    *   **Casse :** Convertissez généralement le texte en une casse cohérente (par exemple, minuscules) à moins que votre framework/tokenizer TTS ne gère la casse de manière appropriée. Consultez la documentation du framework.
+    *   **Caractères spéciaux :** Supprimez ou remplacez les caractères susceptibles de perturber le tokenizer (par exemple, les emojis, les caractères de contrôle).
+
+    ```
+    # Exemple de structure :
+    my_tts_dataset/
+    ├── normalized_chunks/
+    │   ├── segment_00001.wav
+    │   ├── segment_00002.wav
+    │   └── ...
+    └── transcripts/
+        ├── segment_00001.txt  # Contient "Hello world."
+        ├── segment_00002.txt  # Contient "This is a test sentence."
+        └── ...
+    ```
+
+### 1.6. Structuration des données et création du fichier manifest
+
+-   **Objectif :** Créer des fichiers d'index (manifests) qui indiquent au script d'entraînement TTS où trouver les fichiers audio et leurs transcriptions correspondantes.
+-   **Format du manifest :** Le format le plus courant est un fichier texte brut où chaque ligne représente une paire audio-texte, séparée par un délimiteur (généralement une barre verticale `|`).
+    ```
+    path/to/audio_chunk.wav|The corresponding transcription text|speaker_id
+    ```
+    *   `path/to/audio_chunk.wav` : Chemin relatif vers le fichier audio normalisé depuis le répertoire où le script d'entraînement sera exécuté.
+    *   `The corresponding transcription text` : Le texte nettoyé et normalisé issu du fichier `.txt`.
+    *   `speaker_id` : Un identifiant pour le locuteur (par exemple, `speaker0`, `mary_smith`). Pour les jeux de données à locuteur unique, utilisez le même ID pour toutes les lignes. Pour les jeux de données multi-locuteurs, utilisez des ID uniques pour chaque locuteur distinct.
+-   **Division des données (Entraînement/Validation) :** Divisez vos données en un jeu d'entraînement (utilisé pour mettre à jour les poids du modèle) et un jeu de validation (utilisé pour surveiller les performances sur des données inédites et éviter l'overfitting). Une division courante est de 90 à 98 % pour l'entraînement et de 2 à 10 % pour la validation. **Point crucial : assurez-vous, dans la mesure du possible, que des segments provenant *du même enregistrement long d'origine* ne se retrouvent pas à la fois dans les jeux d'entraînement et de validation, afin d'éviter les fuites de données.** En cas de division aléatoire, mélangez d'abord.
+-   **Script de génération des manifests :**
+
+    ```python
+    import os
+    import random
+
+    # --- Configuration ---
+    dataset_name = "my_tts_dataset"
+    normalized_audio_dir = os.path.join(dataset_name, "normalized_chunks")
+    transcripts_dir = os.path.join(dataset_name, "transcripts")
+    output_dir = dataset_name # Où les fichiers manifest seront enregistrés
+
+    train_manifest_path = os.path.join(output_dir, "train_list.txt")
+    val_manifest_path = os.path.join(output_dir, "val_list.txt")
+
+    speaker_id = "main_speaker" # Utilisez un ID cohérent pour les jeux de données à locuteur unique
+                                # Pour le multi-locuteurs, déterminez l'ID selon le nom de fichier ou la source
+    val_split_ratio = 0.05    # 5 % pour le jeu de validation
+    random_seed = 42          # Pour des divisions reproductibles
+    # ---------------------
+
+    manifest_entries = []
+    print("Reading audio and transcript files...")
+
+    # Itère sur les fichiers audio normalisés
+    wav_files = sorted([f for f in os.listdir(normalized_audio_dir) if f.endswith(".wav")])
+
+    for wav_filename in wav_files:
+        base_filename = os.path.splitext(wav_filename)[0]
+        txt_filename = base_filename + ".txt"
+        
+        audio_path = os.path.join(normalized_audio_dir, wav_filename)
+        # Utilisez os.path.relpath si votre script d'entraînement s'exécute depuis une racine différente
+        # relative_audio_path = os.path.relpath(audio_path, start=training_script_dir) 
+        relative_audio_path = audio_path # En supposant que le script s'exécute depuis la racine contenant 'my_tts_dataset'
+
+        transcript_path = os.path.join(transcripts_dir, txt_filename)
+
+        if os.path.exists(transcript_path):
+            try:
+                with open(transcript_path, "r", encoding="utf-8") as f:
+                    transcript = f.read().strip()
+                
+                # Nettoyage de base : supprime les caractères pipe, supprime les espaces superflus
+                transcript = transcript.replace('|', ' ').strip()
+                transcript = ' '.join(transcript.split()) # Normalise les espaces
+
+                if transcript: # S'assure que la transcription n'est pas vide après nettoyage
+                    manifest_entries.append(f"{relative_audio_path}|{transcript}|{speaker_id}")
+                else:
+                    print(f"Warning: Empty transcript for {wav_filename}. Skipping.")
+            except Exception as e:
+                print(f"Error reading or processing transcript {txt_filename}: {e}. Skipping.")
+        else:
+            print(f"Warning: Missing transcript file {txt_filename} for {wav_filename}. Skipping.")
+
+    print(f"Found {len(manifest_entries)} valid audio-transcript pairs.")
+
+    # Mélange et division
+    random.seed(random_seed)
+    random.shuffle(manifest_entries)
+
+    split_idx = int(len(manifest_entries) * (1 - val_split_ratio))
+    train_entries = manifest_entries[:split_idx]
+    val_entries = manifest_entries[split_idx:]
+
+    # Écrit les fichiers manifest
+    try:
+        with open(train_manifest_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(train_entries))
+        print(f"Successfully wrote {len(train_entries)} entries to {train_manifest_path}")
+
+        with open(val_manifest_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(val_entries))
+        print(f"Successfully wrote {len(val_entries)} entries to {val_manifest_path}")
+    except Exception as e:
+        print(f"Error writing manifest files: {e}")
+
+    ```
+
+---
+
+## 2. Checklist de qualité des données
+
+Avant de passer à la configuration de l'entraînement, examinez rigoureusement votre jeu de données préparé à l'aide de cette checklist. Corriger les problèmes maintenant vous fera gagner un temps considérable par la suite.
+
+| Aspect                  | Vérification                                                          | Pourquoi est-ce important ?                                | Action en cas d'échec                                                                  |
+| :---------------------- | :-------------------------------------------------------------------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| **Complétude audio**    | Tous les fichiers `.wav` listés dans les manifests existent-ils réellement ? | L'entraînement plantera si des fichiers sont manquants.    | Régénérez les manifests ; vérifiez les chemins ; assurez-vous qu'aucun fichier n'a été supprimé par accident. |
+| **Correspondance des transcriptions** | Chaque `.wav` a-t-il un `.txt`/une transcription correspondant(e) et précis(e) ? | Des paires incohérentes enseignent au modèle des associations incorrectes. | Vérifiez les noms de fichiers ; révisez la sortie ASR ; corrigez manuellement les transcriptions. |
+| **Durée audio**         | La plupart des segments sont-ils dans la plage souhaitée (par ex. 2-15 s) ? Peu de valeurs aberrantes ? | Les segments très courts/longs peuvent déstabiliser l'entraînement. | Relancez le découpage avec des paramètres ajustés ; filtrez manuellement les valeurs aberrantes des manifests. |
+| **Qualité audio**       | Écoutez des échantillons aléatoires : Faible bruit de fond ? Pas de musique/réverbération/écho ? | Garbage In, Garbage Out. Le modèle apprend le bruit.       | Améliorez l'audio source ; appliquez une réduction du bruit (avec précaution !) ; filtrez les mauvais segments. |
+| **Cohérence du locuteur** | Pour le locuteur unique : Est-ce toujours la voix cible ? Pas d'autres locuteurs ? | Évite la dilution ou l'instabilité de la voix.             | Révisez/filtrez manuellement les segments ; vérifiez les limites de découpage.        |
+| **Format et spécifications** | Tout en WAV ? Sampling rate **identique** ? Canaux mono ? PCM 16 bits ? | Les incohérences provoquent des erreurs ou de mauvaises performances. | Relancez les étapes de conversion/rééchantillonnage (Section 1.1). Vérifiez les spécifications par lots avec des outils en ligne de commande comme `ffprobe` ou `soxi` (qui fait partie du paquet [SoX](http://sox.sourceforge.net/)). Exemple : `soxi -r *.wav` pour vérifier les fréquences. |
+| **Niveaux de volume**   | Écoutez des échantillons aléatoires : Les volumes sont-ils relativement cohérents ? | Des variations de volume drastiques peuvent entraver l'apprentissage. | Relancez la normalisation (Section 1.3) ; vérifiez les paramètres de normalisation.   |
+| **Propreté de la transcription** | Pas d'horodatages, d'étiquettes de locuteur ? Mots de remplissage gérés de manière cohérente ? Ponctuation standard ? Nombres/symboles développés ? | Garantit que le texte correspond proprement aux sons/à la prosodie de la parole. | Relancez les scripts de nettoyage de texte ; effectuez une révision et une correction manuelles. |
+| **Format du manifest**  | Structure `path|text|speaker_id` correcte ? Chemins valides ? Pas de lignes superflues ? | Les erreurs de parseur empêcheront le chargement des données. | Vérifiez le délimiteur (`|`) ; validez les chemins relatifs à l'emplacement du script d'entraînement ; vérifiez l'encodage (UTF-8 de préférence). |
+| **Division Entraînement/Validation** | Les fichiers de validation sont-ils vraiment inédits pendant l'entraînement ? Pas de chevauchement ? | Des données qui se chevauchent donnent des scores de validation trompeurs. | Assurez-vous d'un mélange aléatoire avant la division ; vérifiez la logique de division. |
+
+**Astuce :** Utilisez des outils comme `soxi` (de SoX) ou `ffprobe` pour vérifier par lots les propriétés audio (sampling rate, canaux, durée). Écrivez de petits scripts pour vérifier l'existence des fichiers et le formatage de base du manifest.
+
+### 2.1. Scripts de vérification pratiques
+
+Voici quelques scripts pratiques pour vous aider à vérifier la qualité de votre jeu de données :
+
+#### Vérifier les propriétés audio (Sampling Rate, Canaux, Durée)
+
+```bash
+#!/bin/bash
+# verify_audio.sh - Vérifie les propriétés audio de tous les fichiers WAV
+# Usage : ./verify_audio.sh /path/to/audio/directory
+
+AUDIO_DIR="$1"
+echo "Checking audio files in $AUDIO_DIR..."
+
+# Vérifie si SoX est installé
+if ! command -v soxi &> /dev/null; then
+    echo "SoX not found. Please install it first (e.g., 'apt-get install sox' or 'brew install sox')."
+    exit 1
+fi
+
+# Initialise les compteurs et les tableaux
+total_files=0
+non_mono=0
+wrong_rate=0
+too_short=0
+too_long=0
+target_rate=22050  # Modifiez ceci selon votre sampling rate cible
+min_duration=1.0   # Durée minimale en secondes
+max_duration=15.0  # Durée maximale en secondes
+
+# Traite tous les fichiers WAV
+find "$AUDIO_DIR" -name "*.wav" | while read -r file; do
+    total_files=$((total_files + 1))
+    
+    # Récupère les propriétés audio
+    channels=$(soxi -c "$file")
+    rate=$(soxi -r "$file")
+    duration=$(soxi -d "$file" | awk -F: '{ print ($1 * 3600) + ($2 * 60) + $3 }')
+    
+    # Vérifie les propriétés
+    if [ "$channels" -ne 1 ]; then
+        echo "WARNING: Non-mono file: $file (channels: $channels)"
+        non_mono=$((non_mono + 1))
+    fi
+    
+    if [ "$rate" -ne "$target_rate" ]; then
+        echo "WARNING: Wrong sampling rate: $file (rate: $rate Hz, expected: $target_rate Hz)"
+        wrong_rate=$((wrong_rate + 1))
+    fi
+    
+    if (( $(echo "$duration < $min_duration" | bc -l) )); then
+        echo "WARNING: File too short: $file (duration: ${duration}s, minimum: ${min_duration}s)"
+        too_short=$((too_short + 1))
+    fi
+    
+    if (( $(echo "$duration > $max_duration" | bc -l) )); then
+        echo "WARNING: File too long: $file (duration: ${duration}s, maximum: ${max_duration}s)"
+        too_long=$((too_long + 1))
+    fi
+    
+    # Affiche la progression tous les 100 fichiers
+    if [ $((total_files % 100)) -eq 0 ]; then
+        echo "Processed $total_files files..."
+    fi
+done
+
+# Affiche le résumé
+echo "===== SUMMARY ====="
+echo "Total files checked: $total_files"
+echo "Non-mono files: $non_mono"
+echo "Files with wrong sampling rate: $wrong_rate"
+echo "Files too short (<${min_duration}s): $too_short"
+echo "Files too long (>${max_duration}s): $too_long"
+
+if [ $((non_mono + wrong_rate + too_short + too_long)) -eq 0 ]; then
+    echo "All files passed basic checks!"
+else
+    echo "Some issues were found. Please review the warnings above."
+fi
+```
+
+#### Vérifier l'intégrité du fichier manifest
+
+```python
+#!/usr/bin/env python3
+# verify_manifest.py - Vérifie que tous les fichiers du manifest existent et ont des transcriptions correspondantes
+# Usage : python verify_manifest.py path/to/manifest.txt
+
+import os
+import sys
+from pathlib import Path
+
+def verify_manifest(manifest_path):
+    """Vérifie que tous les fichiers audio et transcriptions du manifest existent et sont valides."""
+    if not os.path.exists(manifest_path):
+        print(f"Error: Manifest file '{manifest_path}' not found.")
+        return False
+    
+    print(f"Verifying manifest: {manifest_path}")
+    base_dir = os.path.dirname(os.path.abspath(manifest_path))
+    
+    # Statistiques
+    total_entries = 0
+    missing_audio = 0
+    empty_transcripts = 0
+    
+    with open(manifest_path, 'r', encoding='utf-8') as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            
+            total_entries += 1
+            
+            # Analyse la ligne (en supposant un format séparé par des pipes : audio_path|transcript|speaker_id)
+            parts = line.split('|')
+            if len(parts) < 2:
+                print(f"Line {line_num}: Invalid format. Expected at least 'audio_path|transcript'")
+                continue
+            
+            audio_path = parts[0]
+            transcript = parts[1]
+            
+            # Vérifie si le chemin audio est relatif et le résout
+            if not os.path.isabs(audio_path):
+                audio_path = os.path.join(base_dir, audio_path)
+            
+            # Vérifie si le fichier audio existe
+            if not os.path.exists(audio_path):
+                print(f"Line {line_num}: Audio file not found: {audio_path}")
+                missing_audio += 1
+            
+            # Vérifie si la transcription est vide
+            if not transcript or transcript.isspace():
+                print(f"Line {line_num}: Empty transcript for {audio_path}")
+                empty_transcripts += 1
+    
+    # Affiche le résumé
+    print("\n===== SUMMARY =====")
+    print(f"Total entries: {total_entries}")
+    print(f"Missing audio files: {missing_audio}")
+    print(f"Empty transcripts: {empty_transcripts}")
+    
+    if missing_audio == 0 and empty_transcripts == 0:
+        print("All manifest entries are valid!")
+        return True
+    else:
+        print("Issues found in manifest. Please fix them before proceeding.")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python verify_manifest.py path/to/manifest.txt")
+        sys.exit(1)
+    
+    success = verify_manifest(sys.argv[1])
+    sys.exit(0 if success else 1)
+```
+
+#### Visualiser les spectrogrammes audio pour évaluer la qualité
+
+Ce script vous aide à inspecter visuellement la qualité de vos fichiers audio en générant des spectrogrammes :
+
+```python
+#!/usr/bin/env python3
+# generate_spectrograms.py - Crée des spectrogrammes pour évaluer la qualité audio
+# Usage : python generate_spectrograms.py /path/to/audio/directory /path/to/output/directory [num_samples]
+
+import os
+import sys
+import random
+import numpy as np
+import matplotlib.pyplot as plt
+import librosa
+import librosa.display
+from pathlib import Path
+
+def generate_spectrograms(audio_dir, output_dir, num_samples=10):
+    """Génère des spectrogrammes pour un échantillon aléatoire de fichiers audio."""
+    # Crée le répertoire de sortie s'il n'existe pas
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Récupère tous les fichiers WAV
+    wav_files = list(Path(audio_dir).glob('**/*.wav'))
+    if not wav_files:
+        print(f"No WAV files found in {audio_dir}")
+        return False
+    
+    # Échantillonne les fichiers s'il y en a plus que demandé
+    if len(wav_files) > num_samples:
+        wav_files = random.sample(wav_files, num_samples)
+    
+    print(f"Generating spectrograms for {len(wav_files)} files...")
+    
+    for i, wav_path in enumerate(wav_files):
+        try:
+            # Charge le fichier audio
+            y, sr = librosa.load(wav_path, sr=None)
+            
+            # Crée une figure avec deux sous-graphiques
+            plt.figure(figsize=(12, 8))
+            
+            # Trace la forme d'onde
+            plt.subplot(2, 1, 1)
+            librosa.display.waveshow(y, sr=sr)
+            plt.title(f'Waveform: {wav_path.name}')
+            plt.xlabel('Time (s)')
+            plt.ylabel('Amplitude')
+            
+            # Trace le spectrogramme
+            plt.subplot(2, 1, 2)
+            D = librosa.amplitude_to_db(np.abs(librosa.stft(y)), ref=np.max)
+            librosa.display.specshow(D, sr=sr, x_axis='time', y_axis='log')
+            plt.colorbar(format='%+2.0f dB')
+            plt.title('Log-frequency power spectrogram')
+            
+            # Enregistre la figure
+            output_path = os.path.join(output_dir, f'spectrogram_{i+1}_{wav_path.stem}.png')
+            plt.tight_layout()
+            plt.savefig(output_path)
+            plt.close()
+            
+            print(f"Generated: {output_path}")
+            
+        except Exception as e:
+            print(f"Error processing {wav_path}: {e}")
+    
+    print(f"Spectrograms saved to {output_dir}")
+    return True
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python generate_spectrograms.py /path/to/audio/directory /path/to/output/directory [num_samples]")
+        sys.exit(1)
+    
+    audio_dir = sys.argv[1]
+    output_dir = sys.argv[2]
+    num_samples = int(sys.argv[3]) if len(sys.argv) > 3 else 10
+    
+    success = generate_spectrograms(audio_dir, output_dir, num_samples)
+    sys.exit(0 if success else 1)
+```
+
+Ces scripts fournissent des outils pratiques pour vérifier la qualité de votre jeu de données avant l'entraînement, vous aidant à identifier et corriger les problèmes tôt dans le processus.
+
+---
+
+Une fois que votre jeu de données a passé ce contrôle de qualité, vous êtes prêt à passer à la configuration de l'environnement d'entraînement.
+
+**Étape suivante :** [Configuration de l'entraînement](./2_TRAINING_SETUP.md){: .btn .btn-primary} |
+[Retour en haut](#top){: .btn .btn-primary}

--- a/languages/fr/guides/2_TRAINING_SETUP.md
+++ b/languages/fr/guides/2_TRAINING_SETUP.md
@@ -1,0 +1,253 @@
+# Guide 2 : Configuration et paramétrage de l'environnement d'entraînement
+
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape précédente : Préparation des données](./1_DATA_PREPARATION.md){: .btn .btn-primary} | [Étape suivante : Entraînement du modèle](./3_MODEL_TRAINING.md){: .btn .btn-primary}
+
+Une fois votre jeu de données préparé, l'étape suivante consiste à configurer l'environnement logiciel nécessaire et à paramétrer les options pour votre exécution d'entraînement spécifique.
+
+---
+
+## 3. Configuration de l'environnement d'entraînement
+
+Cette section couvre l'installation des logiciels requis et l'organisation de vos fichiers de projet.
+
+### 3.1. Choisir et cloner un framework TTS
+
+-   **Sélectionner un framework :** Choisissez une base de code TTS adaptée à vos objectifs. Tenez compte de facteurs comme :
+    *   **Architecture :** VITS, StyleTTS2, Tacotron2+Vocoder, etc. Les architectures plus récentes offrent souvent une meilleure qualité.
+    *   **Prise en charge du fine-tuning :** Le framework prend-il explicitement en charge le fine-tuning à partir de modèles pré-entraînés ? C'est souvent plus facile que l'entraînement à partir de zéro.
+    *   **Prise en charge linguistique :** Vérifiez si le modèle/tokenizer gère bien votre langue cible.
+    *   **Communauté et maintenance :** Le dépôt est-il activement maintenu ? Existe-t-il des discussions communautaires ou des canaux de support ?
+    *   **Modèles pré-entraînés :** Le framework fournit-il des modèles pré-entraînés adaptés comme point de départ pour le fine-tuning ?
+
+#### Comparaison des architectures TTS
+
+Lors de la sélection d'une architecture TTS, prenez en compte ces options populaires et leurs caractéristiques :
+
+| Architecture | Avantages | Inconvénients | Idéal pour | Configuration matérielle requise |
+|:-------------|:-----|:-----|:---------|:---------------------|
+| **VITS** | • Bout en bout (pas de vocoder séparé)<br>• Audio de haute qualité<br>• Inférence rapide<br>• Bon pour le fine-tuning | • Complexe à comprendre<br>• Peut être instable pendant l'entraînement<br>• Nécessite un réglage minutieux des hyperparamètres | • Clonage vocal à locuteur unique<br>• Projets nécessitant une sortie de haute qualité<br>• Lorsque vous disposez de plus de 5 heures de données | • Entraînement : 8 Go+ de VRAM<br>• Inférence : 4 Go+ de VRAM |
+| **StyleTTS2** | • Excellent contrôle de la voix et du style<br>• Qualité à la pointe de la technologie<br>• Bon pour l'émotion/la prosodie | • Plus récent, implémentations potentiellement moins stables<br>• Architecture plus complexe<br>• Moins de ressources communautaires | • Projets nécessitant un contrôle du style<br>• Synthèse vocale expressive<br>• Multi-locuteurs avec transfert de style | • Entraînement : 12 Go+ de VRAM<br>• Inférence : 6 Go+ de VRAM |
+| **Tacotron2 + HiFi-GAN** | • Bien établi, stable<br>• Plus facile à comprendre<br>• Plus de tutoriels disponibles<br>• Composants séparés pour un débogage plus facile | • Pipeline en deux étapes (plus lent)<br>• Qualité généralement inférieure aux modèles plus récents<br>• Plus sujet aux échecs d'attention sur les textes longs | • Projets éducatifs<br>• Lorsque la stabilité prime sur la qualité<br>• Environnements à faibles ressources | • Entraînement : 6 Go+ de VRAM<br>• Inférence : 2 Go+ de VRAM |
+| **FastSpeech2** | • Non autorégressif (inférence plus rapide)<br>• Plus stable que Tacotron2<br>• Bonne documentation | • Nécessite des alignements de phonèmes<br>• Prétraitement plus complexe<br>• Qualité moindre que VITS/StyleTTS2 | • Applications en temps réel<br>• Lorsque la vitesse d'inférence est critique<br>• Sortie plus contrôlée | • Entraînement : 8 Go+ de VRAM<br>• Inférence : 2 Go+ de VRAM |
+| **YourTTS (variante VITS)** | • Prise en charge multilingue<br>• Clonage vocal zero-shot<br>• Bon pour le transfert linguistique | • Configuration d'entraînement complexe<br>• Nécessite une préparation soignée des données<br>• Peut nécessiter des jeux de données plus volumineux | • Projets multilingues<br>• Clonage vocal interlingue<br>• Lorsque la flexibilité linguistique est nécessaire | • Entraînement : 10 Go+ de VRAM<br>• Inférence : 4 Go+ de VRAM |
+| **TTS basé sur la diffusion** | • Potentiel de qualité le plus élevé<br>• Prosodie plus naturelle<br>• Meilleure gestion des mots rares | • Inférence très lente<br>• Entraînement extrêmement gourmand en calcul<br>• Plus récent, moins établi | • Génération hors ligne<br>• Lorsque la qualité prime sur la vitesse<br>• Projets de recherche | • Entraînement : 16 Go+ de VRAM<br>• Inférence : 8 Go+ de VRAM |
+
+**Remarque sur la configuration matérielle requise :**
+- Ce sont des minimums approximatifs ; des batch sizes ou des configurations de modèle plus importants nécessiteront plus de VRAM
+- Les durées d'entraînement varient considérablement : VITS/StyleTTS2 nécessitent généralement plus d'epochs que Tacotron2
+- L'inférence sur CPU est possible pour tous les modèles mais sera nettement plus lente
+
+### 1.3. Configuration matérielle détaillée requise
+
+Choisir le bon matériel est essentiel pour réussir l'entraînement d'un modèle TTS. Voici un détail des exigences pour différents scénarios :
+
+#### Exigences GPU par type de modèle et taille de jeu de données
+
+| Type de modèle | Petit jeu de données (<10h) | Jeu de données moyen (10-50h) | Grand jeu de données (>50h) | Modèles de GPU recommandés |
+|:-----------|:---------------------|:------------------------|:---------------------|:-----------------------|
+| **Tacotron2 + HiFi-GAN** | 8 Go de VRAM | 12 Go de VRAM | 16 Go+ de VRAM | RTX 3060, RTX 2080, T4 |
+| **FastSpeech2** | 8 Go de VRAM | 12 Go de VRAM | 16 Go+ de VRAM | RTX 3060, RTX 2080, T4 |
+| **VITS** | 12 Go de VRAM | 16 Go de VRAM | 24 Go+ de VRAM | RTX 3080, RTX 3090, A5000 |
+| **StyleTTS2** | 16 Go de VRAM | 24 Go de VRAM | 32 Go+ de VRAM | RTX 3090, RTX 4090, A100 |
+| **XTTS-v2** | 24 Go de VRAM | 32 Go de VRAM | 40 Go+ de VRAM | RTX 4090, A100, A6000 |
+| **TTS basé sur la diffusion** | 16 Go de VRAM | 24 Go de VRAM | 32 Go+ de VRAM | RTX 3090, RTX 4090, A100 |
+
+#### CPU et mémoire système
+
+| Échelle d'entraînement | Exigences CPU | RAM système | Stockage |
+|:---------------|:-----------------|:-----------|:--------|
+| **Loisir/Personnel** | 4+ cœurs, 2,5 GHz+ | 16 Go | SSD 50 Go |
+| **Recherche** | 8+ cœurs, 3,0 GHz+ | 32 Go | SSD 100 Go+ |
+| **Production** | 16+ cœurs, 3,5 GHz+ | 64 Go+ | SSD NVMe 500 Go+ |
+
+#### Options de GPU cloud et coûts approximatifs
+
+| Fournisseur cloud | Option GPU | VRAM | Coût approx./heure | Idéal pour |
+|:---------------|:-----------|:-----|:------------------|:---------|
+| **Google Colab** | T4/P100 (Gratuit)<br>V100/A100 (Pro) | 16 Go<br>16-40 Go | Gratuit<br>10-15 $ | Expérimentation, petits jeux de données |
+| **Kaggle** | P100/T4 | 16 Go | Gratuit (heures limitées) | Petits à moyens jeux de données |
+| **AWS** | g4dn.xlarge (T4)<br>p3.2xlarge (V100)<br>p4d.24xlarge (A100) | 16 Go<br>16 Go<br>40 Go | 0,50-0,75 $<br>3,00-3,50 $<br>20,00-32,00 $ | Toute échelle, production |
+| **GCP** | n1-standard-8 + T4<br>a2-highgpu-1g (A100) | 16 Go<br>40 Go | 0,35-0,50 $<br>3,80-4,50 $ | Toute échelle, production |
+| **Azure** | NC6s_v3 (V100)<br>NC24ads_A100_v4 | 16 Go<br>80 Go | 3,00-3,50 $<br>16,00-24,00 $ | Toute échelle, production |
+| **Lambda Labs** | 1x RTX 3090<br>1x A100 | 24 Go<br>40 Go | 1,10 $<br>1,99 $ | Recherche, jeux de données moyens |
+| **Vast.ai** | Divers GPU grand public | 8-24 Go | 0,20-1,00 $ | Entraînement à budget maîtrisé |
+
+#### Estimations de durée d'entraînement
+
+| Modèle | Taille du jeu de données | GPU | Durée d'entraînement approximative | Epochs jusqu'à convergence |
+|:------|:-------------|:----|:--------------------------|:----------------------|
+| **Tacotron2 + HiFi-GAN** | 10 heures | RTX 3080 | 2-3 jours | 50-100K steps |
+| **FastSpeech2** | 10 heures | RTX 3080 | 2-3 jours | 150-200K steps |
+| **VITS** | 10 heures | RTX 3090 | 3-5 jours | 300-500K steps |
+| **StyleTTS2** | 10 heures | RTX 3090 | 4-7 jours | 500-800K steps |
+| **XTTS-v2** | 10 heures | RTX 4090 | 5-10 jours | 1M+ steps |
+
+#### Conseils d'optimisation pour réduire la configuration matérielle requise
+
+1. **Accumulation de gradient (Gradient Accumulation)** : Simulez des batch sizes plus importants en accumulant les gradients sur plusieurs passes avant/arrière
+2. **Entraînement en précision mixte (Mixed Precision Training)** : Utilisez le FP16 au lieu du FP32 pour réduire l'utilisation de la VRAM jusqu'à 50 %
+3. **Gradient Checkpointing** : Échangez du calcul contre de la mémoire en recalculant les activations lors de la passe arrière
+4. **Parallélisme de modèle (Model Parallelism)** : Répartissez les grands modèles sur plusieurs GPU
+5. **Entraînement progressif (Progressive Training)** : Commencez par des modèles/configurations plus petits et augmentez progressivement la complexité
+
+Ces exigences devraient vous aider à planifier vos besoins matériels en fonction des objectifs spécifiques de votre projet et de vos contraintes budgétaires.
+-   **Cloner le dépôt :** Une fois choisi, clonez le dépôt de code du framework à l'aide de Git.
+    ```bash
+    git clone <URL_OF_YOUR_CHOSEN_TTS_REPO>
+    cd <TTS_REPO_DIRECTORY> # Naviguez dans le répertoire cloné
+    ```
+    *   Exemple : `git clone https://github.com/some-user/some-tts-framework.git`
+
+### 3.2. Configurer l'environnement Python et installer les dépendances
+
+-   **Environnement virtuel (Recommandé) :** Créez et activez un environnement virtuel Python dédié pour isoler les dépendances et éviter les conflits avec d'autres projets ou les paquets Python du système.
+    *   **Avec `venv` (intégré) :**
+        ```bash
+        python -m venv venv_tts  # Crée un environnement nommé 'venv_tts'
+        # Activez-le :
+        # Windows : .\venv_tts\Scripts\activate
+        # Linux/macOS : source venv_tts/bin/activate
+        ```
+    *   **Avec `conda` :**
+        ```bash
+        conda create --name tts_env python=3.9 # Ou la version Python souhaitée
+        conda activate tts_env
+        ```
+-   **Installer PyTorch avec CUDA :** C'est essentiel pour l'accélération GPU. Visitez le [guide d'installation officiel de PyTorch](https://pytorch.org/get-started/locally/) et sélectionnez les options correspondant à votre OS, votre gestionnaire de paquets (`pip` ou `conda`), votre plateforme de calcul (version de CUDA) et la version de PyTorch souhaitée. **Assurez-vous que vos pilotes NVIDIA installés sont compatibles avec la version de CUDA choisie.**
+    ```bash
+    # Exemple de commande avec pip pour CUDA 11.8 (vérifiez le site de PyTorch pour les commandes actuelles !)
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+    # Vérifiez l'installation :
+    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); print(torch.version.cuda)"
+    # Devrait afficher la version de PyTorch, True, et votre version de CUDA en cas de succès.
+    ```
+-   **Installer les dépendances du framework :** La plupart des frameworks listent leurs dépendances dans un fichier `requirements.txt`. Installez-les avec `pip` (ou `uv`, qui est souvent plus rapide).
+    ```bash
+    # Naviguez d'abord vers le répertoire du framework si vous n'y êtes pas déjà
+    # Avec pip :
+    pip install -r requirements.txt
+
+    # Avec uv (si installé : pip install uv) :
+    uv pip install -r requirements.txt
+    ```
+    *   **Dépannage :** Soyez attentif à toute erreur d'installation. Elle peut indiquer des bibliothèques système manquantes (comme `libsndfile`), des versions de paquets incompatibles, ou des problèmes avec votre configuration CUDA/PyTorch. Consultez la documentation du framework pour les prérequis spécifiques.
+
+### 3.3. Organiser votre dossier de projet
+
+-   Une structure de dossiers bien organisée facilite la gestion de votre projet. Placez votre jeu de données préparé (ou créez un lien symbolique vers celui-ci) dans ou à côté du code du framework. Une structure courante ressemble à ceci :
+
+    ```bash
+    <YOUR_PROJECT_ROOT>/
+    ├── <TTS_REPO_DIRECTORY>/         # Le code du framework cloné
+    │   ├── train.py                 # Script d'entraînement principal (le nom peut varier)
+    │   ├── inference.py             # Script d'inférence (le nom peut varier)
+    │   ├── configs/                 # Répertoire des fichiers de configuration
+    │   │   └── base_config.yaml     # Exemple de config du framework
+    │   ├── requirements.txt
+    │   └── ... (autres fichiers du framework)
+    │
+    ├── my_tts_dataset/              # Votre jeu de données préparé du Guide 1
+    │   ├── normalized_chunks/       # Fichiers audio finaux
+    │   │   ├── segment_00001.wav
+    │   │   └── ...
+    │   ├── transcripts/             # Optionnel : fichiers texte s'ils ne sont pas directement dans le manifest
+    │   ├── train_list.txt           # Manifest d'entraînement
+    │   └── val_list.txt             # Manifest de validation
+    │
+    ├── checkpoints/                 # Créez ce répertoire : où les modèles seront enregistrés
+    │   └── my_custom_model/         # Sous-répertoire pour une exécution d'entraînement spécifique
+    │
+    └── my_configs/                  # Optionnel : placez vos configs personnalisées ici
+        └── my_training_run_config.yaml
+    ```
+-   **Chemins :** Assurez-vous que les chemins spécifiés ultérieurement dans votre fichier de configuration (pour les jeux de données, les sorties) sont corrects par rapport à l'endroit où vous *exécuterez* le script `train.py` (généralement depuis le `<TTS_REPO_DIRECTORY>`).
+
+---
+
+## 4. Paramétrer l'exécution de l'entraînement
+
+Avant de lancer l'entraînement, vous devez créer un fichier de configuration qui indique au framework *comment* entraîner le modèle, en utilisant *vos* données spécifiques.
+
+### 4.1. Trouver et copier une configuration de base
+
+-   **Localiser des exemples :** Explorez le répertoire `configs/` au sein du framework TTS. Recherchez des fichiers de configuration (`.yaml`, `.json`, ou similaires) servant de modèles.
+-   **Choisir judicieusement :** Sélectionnez un fichier de configuration qui correspond à votre objectif :
+    *   **Fine-tuning :** Recherchez des noms comme `config_ft.yaml`, `finetune_*.yaml`. Ils supposent souvent que vous fournirez un modèle pré-entraîné.
+    *   **Entraînement à partir de zéro :** Recherchez des noms comme `config_base.yaml`, `train_*.yaml`.
+    *   **Taille du jeu de données :** Certains frameworks peuvent proposer des configs réglées pour les petits (`_sm`) ou grands (`_lg`) jeux de données.
+-   **Copier et renommer :** Copiez le fichier modèle choisi vers un nouvel emplacement (par exemple, votre propre répertoire `my_configs/` ou dans le répertoire `configs/` du framework) et donnez-lui un nom descriptif pour votre exécution spécifique (par exemple, `my_yoruba_voice_ft_config.yaml`).
+    ```bash
+    # Exemple : Copier une config de fine-tuning
+    cp <TTS_REPO_DIRECTORY>/configs/base_finetune_config.yaml my_configs/my_yoruba_voice_ft_config.yaml
+    ```
+
+### 4.2. Éditer votre fichier de configuration personnalisé
+
+-   Ouvrez votre fichier de configuration nouvellement copié (`my_yoruba_voice_ft_config.yaml`) dans un éditeur de texte.
+-   **Modifier les paramètres clés :** Examinez et modifiez soigneusement les paramètres. Les noms des paramètres **varieront considérablement** d'un framework à l'autre, mais les catégories courantes incluent :
+
+    ```yaml
+    # --- Jeu de données et chargement des données ---
+    # Chemins relatifs à l'endroit où vous exécutez train.py
+    train_filelist_path: "../my_tts_dataset/train_list.txt" # Chemin vers votre manifest d'entraînement
+    val_filelist_path: "../my_tts_dataset/val_list.txt"   # Chemin vers votre manifest de validation
+    # Certains frameworks peuvent nécessiter 'data_path' ou 'audio_root' pointant vers le répertoire audio à la place/en plus.
+
+    # --- Sortie et journalisation ---
+    output_directory: "../checkpoints/my_yoruba_voice_run1" # TRÈS IMPORTANT : où les modèles, logs, échantillons sont enregistrés. Créez ce répertoire de base si nécessaire.
+    log_interval: 100                  # Fréquence (en steps/batches) d'affichage des logs
+    validation_interval: 1000          # Fréquence (en steps/batches) d'exécution de la validation
+    save_checkpoint_interval: 5000     # Fréquence (en steps/batches) de sauvegarde des checkpoints du modèle
+
+    # --- Hyperparamètres principaux d'entraînement ---
+    epochs: 1000                       # Nombre total de passes sur les données d'entraînement. À ajuster selon la taille du jeu de données et la convergence.
+    batch_size: 16                     # Nombre d'échantillons traités en parallèle par GPU. DIMINUEZ en cas d'erreurs CUDA OOM. AUGMENTEZ pour un entraînement plus rapide si la VRAM le permet.
+    learning_rate: 1e-4                # Taux d'apprentissage initial. Peut nécessiter un réglage (par ex. plus bas pour le fine-tuning : 5e-5 ou 1e-5).
+    # lr_scheduler: "cosine_decay"     # Planification du learning rate (par ex. step decay, exponential decay) - dépend du framework
+    # weight_decay: 0.01               # Paramètre de régularisation
+
+    # --- Paramètres audio ---
+    sampling_rate: 22050               # CRITIQUE : DOIT correspondre au sampling rate de votre jeu de données préparé (du Guide 1).
+    # Autres paramètres audio (dépendent souvent de l'architecture du modèle) :
+    # filter_length: 1024              # Taille de la FFT pour la STFT
+    # hop_length: 256                  # Pas (hop size) pour la STFT
+    # win_length: 1024                 # Taille de fenêtre pour la STFT
+    # n_mel_channels: 80               # Nombre de bandes mel
+    # mel_fmin: 0.0                    # Fréquence mel minimale
+    # mel_fmax: 8000.0                 # Fréquence mel maximale (souvent sampling_rate / 2)
+
+    # --- Architecture du modèle ---
+    # model_type: "VITS"               # Type d'architecture du modèle
+    # hidden_channels: 192             # Taille des couches internes
+    # num_speakers: 1                  # Définir à >1 pour les jeux de données multi-locuteurs (doit correspondre à la préparation des données)
+
+    # --- Spécificités du fine-tuning (si applicable) ---
+    # Définir 'True' ou fournir un chemin lors du fine-tuning
+    fine_tuning: True
+    pretrained_model_path: "/path/to/downloaded/base_model.pth" # Chemin vers le checkpoint pré-entraîné de départ.
+    # Optionnel : Spécifier les couches à ignorer/réinitialiser si nécessaire
+    # ignore_layers: ["speaker_embedding.weight", "decoder.output_layer.weight"]
+    ```
+-   **Lire la documentation du framework :** Consultez la documentation spécifique de votre framework TTS choisi pour comprendre ce que fait chaque paramètre de son fichier de configuration.
+
+### 4.3. Considérations matérielles et relatives au jeu de données
+
+-   **VRAM du GPU :** Le `batch_size` est le principal levier pour contrôler l'utilisation de la mémoire GPU. Commencez par une valeur recommandée (par exemple, 16 ou 32) et diminuez-la si vous rencontrez des erreurs « CUDA out of memory » au démarrage de l'entraînement. Des batch sizes plus importants conduisent généralement à une convergence plus rapide mais nécessitent plus de VRAM.
+-   **Taille du jeu de données vs Epochs :**
+    *   **Petits jeux de données (< 20h) :** Peuvent nécessiter moins d'epochs (par exemple, 300-1500) mais demandent un suivi attentif via la validation loss/les échantillons pour éviter l'overfitting (lorsque le modèle mémorise les données d'entraînement mais performe mal sur un nouveau texte). Envisagez des learning rates plus faibles.
+    *   **Grands jeux de données (> 50h) :** Peuvent bénéficier de davantage d'epochs (1000+) pour apprendre pleinement les motifs présents dans les données.
+-   **CPU :** Bien que le GPU fasse le gros du travail, un CPU multicœur correct est nécessaire pour le chargement et le prétraitement des données, qui peuvent autrement devenir un goulot d'étranglement.
+-   **Stockage :** Assurez-vous d'avoir assez d'espace disque pour le jeu de données, l'environnement Python, le code du framework, et surtout les checkpoints sauvegardés, qui peuvent devenir volumineux (de centaines de Mo à plusieurs Go par checkpoint).
+
+### 4.4. Outils de suivi (TensorBoard)
+
+-   La plupart des frameworks TTS modernes s'intègrent avec [TensorBoard](https://www.tensorflow.org/tensorboard) pour visualiser la progression de l'entraînement.
+-   Le fichier de configuration comporte souvent des paramètres relatifs à la journalisation (par exemple, `use_tensorboard: True`, `log_directory`).
+-   Pendant l'entraînement, vous pouvez généralement lancer TensorBoard en exécutant `tensorboard --logdir <YOUR_OUTPUT_DIRECTORY>` (par exemple, `tensorboard --logdir ../checkpoints/my_yoruba_voice_run1`) dans un terminal séparé. Cela vous permet de suivre les courbes de loss, les learning rates et potentiellement d'écouter les échantillons de validation synthétisés dans votre navigateur web.
+
+---
+
+Avec votre environnement configuré et votre fichier de configuration adapté à vos données et objectifs, vous êtes maintenant prêt à démarrer le processus d'entraînement proprement dit du modèle.
+
+**Étape suivante :** [Entraînement du modèle](./3_MODEL_TRAINING.md){: .btn .btn-primary} | 
+[Retour en haut](#top){: .btn .btn-primary}

--- a/languages/fr/guides/3_MODEL_TRAINING.md
+++ b/languages/fr/guides/3_MODEL_TRAINING.md
@@ -1,0 +1,281 @@
+# Guide 3 : Entraînement et fine-tuning du modèle
+
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape précédente : Configuration de l'entraînement](./2_TRAINING_SETUP.md){: .btn .btn-primary} | [Étape suivante : Inférence](./4_INFERENCE.md){: .btn .btn-primary}
+
+Vous avez préparé vos données et configuré votre environnement d'entraînement. Il est maintenant temps d'entraîner (ou d'affiner) votre modèle de synthèse vocale. Cette phase implique l'exécution du script d'entraînement, le suivi de sa progression et la compréhension de la gestion du processus.
+
+---
+
+## 5. Lancer l'entraînement
+
+Cette section détaille comment lancer, suivre et gérer le processus d'entraînement.
+
+### 5.1. Lancer le script d'entraînement
+
+-   **Naviguer vers le bon répertoire :** Ouvrez votre terminal ou invite de commande et naviguez dans le répertoire principal du dépôt du framework TTS cloné (le répertoire contenant le script `train.py` ou son équivalent).
+-   **Activer l'environnement virtuel :** Assurez-vous que votre environnement virtuel Python dédié (par exemple, `venv_tts`, `tts_env`) est activé.
+    ```bash
+    # Exemple d'activation (ajustez le chemin/nom selon les besoins)
+    # Windows : ..\venv_tts\Scripts\activate
+    # Linux/macOS : source ../venv_tts/bin/activate
+    # Conda : conda activate tts_env
+    ```
+-   **Exécuter la commande d'entraînement :** Lancez le script d'entraînement du framework, en le pointant vers votre fichier de configuration personnalisé créé au Guide 2. La structure exacte de la commande varie d'un framework à l'autre. Les schémas courants incluent :
+    ```bash
+    # Schéma courant 1 : Utilisation de l'argument --config
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml
+
+    # Schéma courant 2 : Utilisation de -c pour la config et -m pour le nom du répertoire de modèle/sortie
+    # (Vérifiez si votre output_directory dans la config est remplacé par -m)
+    python train.py -c ../my_configs/my_yoruba_voice_ft_config.yaml -m my_yoruba_voice_run1
+
+    # Schéma courant 3 : Spécifier directement le répertoire de checkpoint
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --checkpoint_path ../checkpoints/my_yoruba_voice_run1
+    ```
+    *   **Entraînement multi-GPU :** Si vous disposez de plusieurs GPU et que le framework prend en charge l'entraînement distribué (consultez sa documentation), vous pourriez utiliser des commandes impliquant `torchrun` ou `python -m torch.distributed.launch`. Exemple :
+        ```bash
+        # Exemple utilisant torchrun (ajustez nproc_per_node à votre nombre de GPU)
+        torchrun --nproc_per_node=2 train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml
+        ```
+
+### 5.2. Suivre la progression de l'entraînement
+
+-   **Sortie console :** Le terminal où vous avez lancé l'entraînement affichera des informations de progression. Recherchez :
+    *   **Initialisation :** Messages indiquant que le modèle est en cours de construction, que les chargeurs de données sont en cours de préparation et potentiellement qu'un modèle pré-entraîné est en cours de chargement (pour le fine-tuning).
+    *   **Epochs/Steps :** Progression actuelle de l'entraînement (par exemple, `Epoch: [1/1000]`, `Step: [500/100000]`).
+    *   **Valeurs de loss :** Métriques cruciales indiquant la qualité de l'apprentissage du modèle. Attendez-vous à voir `train_loss` (loss sur le batch courant) et, périodiquement, `validation_loss` (loss sur le jeu de validation inédit). Les deux devraient généralement diminuer au fil du temps. Des composantes de loss spécifiques (comme `mel_loss`, `duration_loss`, `kl_loss`) peuvent aussi être rapportées selon l'architecture du modèle.
+    *   **Learning Rate :** Le learning rate actuel peut être affiché, surtout si un scheduler le réduit au fil du temps.
+    *   **Horodatages/Vitesse :** Temps pris par step ou par epoch.
+-   **TensorBoard (Fortement recommandé) :** S'il est activé dans votre config, utilisez TensorBoard pour un suivi visuel.
+    *   **Lancement :** Ouvrez un *nouveau* terminal (gardez celui de l'entraînement en cours d'exécution), activez le même environnement virtuel, et lancez :
+        ```bash
+        # Pointez logdir vers le output_directory spécifié dans votre config
+        tensorboard --logdir ../checkpoints/my_yoruba_voice_run1
+        ```
+    *   **Accès :** Ouvrez l'URL fournie par TensorBoard (généralement `http://localhost:6006/`) dans votre navigateur web.
+    *   **Visualisation :** Vous pouvez voir des graphiques des losses d'entraînement et de validation au fil du temps, les planifications du learning rate et potentiellement d'autres métriques.
+    *   **Écouter les échantillons audio :** De nombreux frameworks journalisent périodiquement des échantillons audio synthétisés à partir du jeu de validation vers TensorBoard (vérifiez l'onglet `AUDIO`). Les écouter est la *meilleure* façon d'évaluer qualitativement l'amélioration du modèle et d'identifier des problèmes comme le bruit, les erreurs de prononciation ou une sortie robotique.
+-   **Répertoire de sortie :** Vérifiez le `output_directory` que vous avez spécifié dans votre config (`../checkpoints/my_yoruba_voice_run1`). Il devrait contenir :
+    *   Les checkpoints du modèle sauvegardés (fichiers `.pth`, `.pt`, `.ckpt`).
+    *   Les fichiers journaux (`train.log`, etc.).
+    *   Des copies du fichier de configuration utilisé.
+    *   Les fichiers d'événements TensorBoard (généralement dans un sous-répertoire `logs` ou `events`).
+    *   Éventuellement des échantillons audio synthétisés.
+
+### 5.3. Comprendre les checkpoints
+
+-   **Ce qu'ils sont :** Les checkpoints sont des instantanés de l'état du modèle (tous ses poids appris et potentiellement l'état de l'optimiseur) sauvegardés à intervalles spécifiques pendant l'entraînement.
+-   **Pourquoi ils sont importants :**
+    *   **Reprise de l'entraînement :** Permettent de continuer l'entraînement s'il est interrompu (en raison de plantages, de coupures de courant ou d'un arrêt manuel).
+    *   **Évaluation de la progression :** Vous pouvez utiliser des checkpoints de différentes étapes pour synthétiser de l'audio et voir comment le modèle a évolué.
+    *   **Sélection du meilleur modèle :** La validation loss aide à identifier les bons checkpoints, mais le *meilleur* modèle est souvent choisi en écoutant l'audio synthétisé à partir de plusieurs checkpoints prometteurs proches de la validation loss la plus basse. Parfois, un checkpoint légèrement antérieur sonne mieux que celui avec la loss absolument la plus basse.
+-   **Fréquence de sauvegarde :** Configurez le `save_checkpoint_interval` dans votre config. Sauvegarder trop souvent consomme de l'espace disque ; sauvegarder trop rarement risque de faire perdre une progression significative en cas de plantage. Sauvegarder tous les quelques milliers de steps ou une fois par epoch est courant. De nombreux frameworks sauvegardent aussi automatiquement le « meilleur » checkpoint en fonction de la validation loss.
+
+### 5.4. Reprendre un entraînement interrompu
+
+-   Si votre entraînement s'arrête de manière inattendue ou que vous l'arrêtez manuellement, vous pouvez généralement reprendre à partir du dernier checkpoint sauvegardé.
+-   Trouvez le chemin vers le dernier fichier de checkpoint dans votre répertoire de sortie (par exemple, `../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth` ou `latest_checkpoint.pth`).
+-   Utilisez l'argument de reprise du framework lors du relancement du script d'entraînement. Le nom de l'argument varie :
+    ```bash
+    # Exemple utilisant --resume_checkpoint
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --resume_checkpoint ../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth
+
+    # Exemple utilisant --restore_path ou --resume_path
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --restore_path ../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth
+    ```
+-   Le script devrait charger les poids du modèle et l'état de l'optimiseur depuis le checkpoint et continuer l'entraînement à partir de ce point.
+
+### 5.5. Quand arrêter l'entraînement
+
+-   **Limite d'epochs :** L'entraînement s'arrête automatiquement lorsque le nombre maximal d'`epochs` spécifié dans la config est atteint.
+-   **Arrêt précoce (Early Stopping) :** Surveillez la `validation_loss`. Si elle cesse de diminuer et commence à augmenter de manière constante pendant une période prolongée (par exemple, sur plusieurs intervalles de validation), le modèle pourrait commencer à faire de l'overfitting. Vous pourriez envisager d'arrêter l'entraînement manuellement autour du point où la validation loss était la plus basse.
+-   **Évaluation qualitative :** Écoutez régulièrement les échantillons audio de validation générés dans TensorBoard ou synthétisez manuellement des échantillons à partir des checkpoints récents. Arrêtez l'entraînement lorsque vous êtes satisfait de la qualité et de la stabilité audio, même si la loss diminue encore légèrement. Un entraînement supplémentaire pourrait ne pas apporter d'améliorations perceptibles, voire dégrader la qualité.
+
+---
+
+## 6. Fine-tuning vs Entraînement à partir de zéro
+
+### 6.1. Choisir votre approche
+
+Au démarrage d'un projet TTS, l'une des décisions les plus importantes est de savoir s'il faut affiner (fine-tuning) un modèle existant ou en entraîner un nouveau à partir de zéro. Ce tableau vous aide à décider quelle approche convient le mieux à votre situation spécifique :
+
+| Facteur | Fine-tuning | Entraînement à partir de zéro |
+|:-------|:------------|:----------------------|
+| **Taille du jeu de données** | Fonctionne bien avec de plus petits jeux de données (5-20 heures)<br>Peut produire de bons résultats avec aussi peu que 1-2 heures pour certaines voix | Nécessite généralement de plus grands jeux de données (30h+)<br>Moins de 20 heures conduit souvent à une qualité médiocre |
+| **Similarité de la voix** | Idéal lorsque votre voix cible est similaire aux voix des données d'entraînement du modèle pré-entraîné | Nécessaire lorsque votre voix cible est très unique ou significativement différente des modèles pré-entraînés disponibles |
+| **Langue** | Fonctionne bien pour le fine-tuning au sein de la même langue<br>Peut fonctionner en interlingue avec une préparation soignée | Requis pour les langues sans modèles pré-entraînés disponibles<br>Meilleur pour capturer la phonétique propre à une langue |
+| **Durée d'entraînement** | Bien plus rapide (jours au lieu de semaines)<br>Nécessite moins d'epochs pour converger | Durée d'entraînement nettement plus longue<br>Peut nécessiter 2 à 5 fois plus d'epochs |
+| **Configuration matérielle requise** | Exigences GPU similaires mais pour moins longtemps<br>Peut souvent utiliser des batch sizes plus petits | Nécessite un accès GPU soutenu pendant de plus longues périodes<br>Peut davantage bénéficier de configurations multi-GPU |
+| **Potentiel de qualité** | Peut atteindre rapidement une excellente qualité<br>Peut hériter des limitations du modèle de base | Flexibilité et potentiel de qualité maximaux<br>Aucune contrainte d'un entraînement antérieur |
+| **Stabilité** | Processus d'entraînement généralement plus stable<br>Moins sujet à l'effondrement ou à la non-convergence | Plus sensible aux hyperparamètres<br>Risque plus élevé d'instabilité de l'entraînement |
+
+#### Quand choisir le fine-tuning
+
+Le fine-tuning est généralement recommandé lorsque :
+- Vous disposez de données limitées (moins de 20 heures)
+- Vous avez besoin de résultats plus rapides
+- Votre voix/langue cible est raisonnablement similaire aux modèles pré-entraînés disponibles
+- Vous disposez de ressources de calcul limitées
+- Vous débutez dans l'entraînement TTS (le fine-tuning est plus tolérant)
+
+#### Quand choisir l'entraînement à partir de zéro
+
+L'entraînement à partir de zéro est préférable lorsque :
+- Vous disposez de données abondantes (30h+)
+- Votre voix cible est très unique ou possède des caractéristiques non représentées dans les modèles pré-entraînés
+- Vous travaillez avec une langue mal prise en charge par les modèles existants
+- Vous avez besoin d'un contrôle maximal sur tous les aspects du modèle
+- Vous avez accès à des ressources de calcul importantes
+- Vous construisez un modèle de fondation que d'autres affineront
+
+### 6.2. Spécificités du fine-tuning
+
+Le fine-tuning tire parti d'un modèle pré-entraîné puissant et l'adapte à votre jeu de données spécifique (locuteur, langue, style). Il est généralement plus rapide et nécessite moins de données que l'entraînement à partir de zéro.
+
+#### L'objectif
+
+-   Transférer les capacités générales de synthèse vocale (comme la compréhension de la correspondance texte-son, la prosodie de base) du grand jeu de données sur lequel le modèle de base a été entraîné, tout en spécialisant l'identité vocale et potentiellement l'accent/le style pour correspondre à votre jeu de données plus petit et spécifique.
+
+### 6.2. Différences clés de configuration (Rappel de la configuration)
+
+-   **`pretrained_model_path` :** Vous DEVEZ fournir le chemin vers le fichier de checkpoint du modèle pré-entraîné dans votre configuration.
+-   **`fine_tuning: True` :** Assurez-vous que tout indicateur signalant le mode fine-tuning est activé si le framework le requiert.
+-   **Learning Rate :** Commencez avec un learning rate *plus bas* que celui généralement utilisé pour l'entraînement à partir de zéro (par exemple, `1e-5`, `2e-5`, `5e-5`). Un learning rate élevé peut détruire les informations précieuses apprises par le modèle pré-entraîné.
+-   **Batch Size :** Peut souvent être similaire à l'entraînement à partir de zéro, à ajuster selon la VRAM.
+-   **Epochs :** Le nombre d'epochs requis pour le fine-tuning est généralement nettement inférieur à celui de l'entraînement à partir de zéro, mais dépend tout de même de la taille du jeu de données et de la qualité souhaitée. Surveillez de près la validation loss et les échantillons audio.
+
+### 6.3. Stratégies possibles (Dépendantes du framework)
+
+-   **Fine-tuning complet du réseau :** L'approche par défaut consiste souvent à mettre à jour les poids de l'ensemble du réseau, mais avec un learning rate faible.
+-   **Gel de couches (Freezing Layers) :** Certains frameworks permettent de geler des parties du réseau (par exemple, l'encodeur de texte ou le prédicteur de durée) initialement et de n'entraîner que des composants spécifiques (comme les speaker embeddings ou le décodeur). Cela peut parfois aider à préserver les forces du modèle de base tout en adaptant des aspects spécifiques. Consultez la documentation de votre framework pour les options `--freeze_layers` ou similaires.
+-   **Ignorer des couches :** Lors du chargement du modèle pré-entraîné, vous pourriez vouloir `ignore_layers` (ou `reinitialize_layers`) comme la couche de sortie finale ou la couche de speaker embedding, surtout si votre jeu de données a un nombre de locuteurs différent de celui du modèle pré-entraîné.
+
+### 6.4. Suivre le fine-tuning
+
+-   **Amélioration initiale rapide :** Vous devriez voir la validation loss chuter relativement rapidement au début, à mesure que le modèle s'adapte à la voix cible.
+-   **Se concentrer sur la qualité audio :** Prêtez une attention particulière aux échantillons de validation synthétisés. L'identité vocale se déplace-t-elle vers votre locuteur cible ? La parole est-elle claire et stable ? Le fine-tuning relève souvent davantage de la qualité perceptive que de l'atteinte de la valeur de loss minimale absolue.
+
+---
+
+## 7. Guide complet de dépannage
+
+L'entraînement de modèles TTS peut être difficile, avec de nombreux problèmes potentiels. Cette section fournit des solutions aux problèmes courants que vous pourriez rencontrer.
+
+### 7.1. Messages d'erreur courants et solutions
+
+| Message d'erreur | Causes possibles | Solutions |
+|:--------------|:----------------|:----------|
+| `CUDA out of memory` | • Batch size trop grand<br>• Modèle trop grand pour le GPU<br>• Fuite de mémoire | • Réduire le batch size<br>• Activer le gradient checkpointing<br>• Utiliser l'entraînement en précision mixte<br>• Réduire la longueur de séquence |
+| `RuntimeError: Expected tensor for argument #1 'indices' to have scalar type Long` | • Type de données incorrect dans le jeu de données<br>• Types de tenseurs incompatibles | • Vérifier le prétraitement des données<br>• S'assurer que tous les tenseurs ont le bon dtype<br>• Ajouter une conversion de type explicite |
+| `ValueError: too many values to unpack` | • Incohérence entre les sorties du modèle et les attentes de la fonction de loss<br>• Format de données incorrect | • Vérifier la structure de sortie du modèle<br>• Vérifier l'implémentation de la fonction de loss<br>• Déboguer les sorties du chargeur de données |
+| `FileNotFoundError: [Errno 2] No such file or directory` | • Chemins incorrects dans la config<br>• Fichiers de données manquants | • Vérifier tous les chemins de fichiers<br>• Vérifier l'intégrité du fichier manifest<br>• S'assurer que les données sont téléchargées/extraites |
+| `KeyError: 'speaker_id'` | • Information de locuteur manquante<br>• Format de jeu de données incorrect | • Vérifier le format du jeu de données<br>• Vérifier le fichier de mappage des locuteurs<br>• Ajouter l'information de locuteur au manifest |
+| `Loss is NaN` | • Learning rate trop élevé<br>• Initialisation instable<br>• Explosion du gradient | • Réduire le learning rate<br>• Ajouter un gradient clipping<br>• Vérifier les divisions par zéro<br>• Normaliser les données d'entrée |
+| `ModuleNotFoundError: No module named 'X'` | • Dépendance manquante<br>• Problème d'environnement | • Installer le paquet manquant<br>• Vérifier l'environnement virtuel<br>• Vérifier les versions des paquets |
+| `RuntimeError: expected scalar type Float but found Double` | • Types de tenseurs incohérents | • Ajouter `.float()` aux tenseurs<br>• Vérifier le prétraitement des données<br>• Standardiser le dtype dans tout le modèle |
+
+### 7.2. Problèmes de qualité de l'entraînement
+
+| Symptôme | Causes possibles | Solutions |
+|:--------|:----------------|:----------|
+| **Audio robotique/grésillant** | • Problèmes de vocoder<br>• Entraînement insuffisant<br>• Mauvais prétraitement audio | • Entraîner le vocoder plus longtemps<br>• Vérifier la normalisation audio<br>• Vérifier la cohérence du sampling rate |
+| **Mots sautés/répétés** | • Problèmes d'attention<br>• Entraînement instable<br>• Données insuffisantes | • Utiliser une guided attention loss<br>• Ajouter plus de variété de données<br>• Réduire le learning rate<br>• Vérifier les longs silences dans les données |
+| **Prononciation incorrecte** | • Problèmes de normalisation du texte<br>• Erreurs de phonèmes<br>• Incompatibilité linguistique | • Améliorer le prétraitement du texte<br>• Utiliser une entrée basée sur les phonèmes<br>• Ajouter un dictionnaire de prononciation |
+| **Perte de l'identité du locuteur** | • Overfitting au locuteur dominant<br>• Speaker embeddings faibles<br>• Données de locuteur insuffisantes | • Équilibrer les données de locuteur<br>• Augmenter la dimension du speaker embedding<br>• Utiliser une speaker adversarial loss |
+| **Convergence lente** | • Problèmes de learning rate<br>• Mauvaise initialisation<br>• Jeu de données complexe | • Essayer différentes planifications de LR<br>• Utiliser le transfert d'apprentissage<br>• Simplifier le jeu de données au départ |
+| **Entraînement instable** | • Variance des batches<br>• Valeurs aberrantes dans le jeu de données<br>• Problèmes d'optimiseur | • Utiliser l'accumulation de gradient<br>• Nettoyer les échantillons aberrants<br>• Essayer différents optimiseurs |
+
+### 7.3. Problèmes spécifiques aux frameworks
+
+#### Coqui TTS
+```
+# Erreur : "RuntimeError: Error in applying gradient to param_name"
+# Solution : Vérifiez les valeurs NaN dans votre jeu de données ou réduisez le learning rate
+python -c "import torch; torch.autograd.set_detect_anomaly(True)"  # À exécuter avant l'entraînement pour déboguer
+
+# Erreur : "ValueError: Tacotron training requires `r` > 1"
+# Solution : Définissez correctement le reduction factor dans la config
+# Exemple de correction dans config.json :
+"r": 2  # Essayez des valeurs entre 2 et 5
+```
+
+#### ESPnet
+```
+# Erreur : "TypeError: forward() missing 1 required positional argument: 'feats'"
+# Solution : Vérifiez le formatage des données et assurez-vous que les feats sont fournis
+# Déboguer le chargement des données :
+python -c "from espnet2.train.dataset import ESPnetDataset; dataset = ESPnetDataset(...); print(dataset[0])"
+```
+
+#### VITS/StyleTTS
+```
+# Erreur : "RuntimeError: expected scalar type Half but found Float"
+# Solution : Assurez une précision cohérente dans tout le modèle
+# Ajoutez à votre script d'entraînement :
+model = model.half()  # Si vous utilisez la précision mixte
+# OU
+model = model.float()  # Si vous n'utilisez pas la précision mixte
+```
+
+### 7.4. Problèmes matériels et d'environnement
+
+1. **Fragmentation de la mémoire GPU**
+   - **Symptôme** : Erreurs OOM après plusieurs heures d'entraînement malgré une VRAM suffisante
+   - **Solution** : Redémarrer périodiquement l'entraînement depuis un checkpoint, utiliser des batches plus petits
+
+2. **Goulots d'étranglement CPU**
+   - **Symptôme** : L'utilisation du GPU fluctue ou reste faible
+   - **Solution** : Augmenter num_workers dans le DataLoader, utiliser un stockage plus rapide, pré-mettre en cache les jeux de données
+
+3. **Goulots d'étranglement d'E/S disque**
+   - **Symptôme** : L'entraînement se bloque périodiquement pendant le chargement des données
+   - **Solution** : Utiliser un stockage SSD, augmenter le prefetch factor, mettre en cache le jeu de données en RAM
+
+4. **Conflits d'environnement**
+   - **Symptôme** : Plantages mystérieux ou erreurs d'import
+   - **Solution** : Utiliser des environnements isolés (conda/venv), vérifier la compatibilité CUDA/PyTorch
+
+### 7.5. Stratégies de débogage
+
+1. **Isoler le problème**
+   ```bash
+   # Tester le chargement des données séparément
+   python -c "from your_framework import DataLoader; loader = DataLoader(...); next(iter(loader))"
+   
+   # Tester la passe avant avec des données factices
+   python -c "import torch; from your_model import Model; model = Model(); x = torch.randn(1, 100); model(x)"
+   ```
+
+2. **Simplifier pour identifier les problèmes**
+   - Entraîner sur un tout petit sous-ensemble (10-20 échantillons)
+   - Désactiver temporairement l'augmentation de données
+   - Essayer d'abord avec un seul locuteur
+
+3. **Visualiser les sorties intermédiaires**
+   - Tracer les alignements d'attention
+   - Visualiser les spectrogrammes mel à différentes étapes
+   - Surveiller les normes de gradient
+
+4. **Activer la journalisation détaillée**
+   ```bash
+   # Ajoutez à votre script d'entraînement
+   import logging
+   logging.basicConfig(level=logging.DEBUG)
+   ```
+
+5. **Utiliser le profilage TensorBoard**
+   ```python
+   # Ajoutez à votre code d'entraînement
+   from torch.profiler import profile, record_function
+   with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+       with record_function("model_inference"):
+           # Votre passe avant
+   print(prof.key_averages().table())
+   ```
+
+---
+
+L'entraînement étant lancé et suivi, l'étape suivante, après avoir sélectionné un bon checkpoint, consiste à utiliser le modèle pour générer de la parole sur un nouveau texte.
+
+**Étape suivante :** [Inférence](./4_INFERENCE.md){: .btn .btn-primary} | 
+[Retour en haut](#top){: .btn .btn-primary}

--- a/languages/fr/guides/4_INFERENCE.md
+++ b/languages/fr/guides/4_INFERENCE.md
@@ -1,0 +1,426 @@
+# Guide 4 : Inférence - Générer de la parole avec votre modèle
+
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape précédente : Entraînement du modèle](./3_MODEL_TRAINING.md){: .btn .btn-primary} | [Étape suivante : Packaging et partage](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+
+Vous avez entraîné ou affiné avec succès un modèle TTS et sélectionné un checkpoint prometteur ! Maintenant, utilisons ce modèle pour convertir un nouveau texte en audio de parole, un processus appelé **inférence** ou **synthèse**.
+
+---
+
+## 7. Inférence : synthétiser la parole
+
+Cette section explique comment exécuter le processus d'inférence à l'aide de votre modèle entraîné.
+
+### 7.1. Localiser le script d'inférence et le meilleur checkpoint
+
+-   **Script d'inférence :** Trouvez le script Python au sein de votre framework TTS conçu pour générer de l'audio. Les noms courants incluent `inference.py`, `synthesize.py`, `infer.py`, `tts.py`.
+-   **Meilleur checkpoint :** Identifiez le chemin vers le checkpoint du modèle (`.pth`, `.pt`, `.ckpt`) que vous souhaitez utiliser. Il s'agit généralement de celui sauvegardé sous `best_model.pth` (basé sur la validation loss) ou d'un autre checkpoint que vous avez sélectionné en écoutant les échantillons de validation pendant l'entraînement. Il se trouvera dans votre répertoire de sortie d'entraînement (par exemple, `../checkpoints/my_yoruba_voice_run1/best_model.pth`).
+-   **Fichier de configuration :** Vous aurez presque toujours besoin du fichier de configuration (`.yaml`, `.json`) qui a été utilisé *pendant l'entraînement* du checkpoint que vous utilisez. Le script d'inférence en a besoin pour connaître l'architecture du modèle, les paramètres audio (comme le sampling rate) et d'autres réglages. Souvent, une copie de la config est sauvegardée à côté des checkpoints.
+
+### 7.2. Inférence basique d'une phrase unique
+
+-   **Objectif :** Générer de l'audio pour un seul morceau de texte fourni directement via la ligne de commande.
+-   **Structure de la commande :** Les arguments exacts varieront, mais une commande typique ressemble à ceci :
+
+    ```bash
+    # Activez d'abord votre environnement virtuel !
+    # Exemple de commande :
+    python inference.py \
+      --config ../checkpoints/my_yoruba_voice_run1/config.yaml \
+      --checkpoint_path ../checkpoints/my_yoruba_voice_run1/best_model.pth \
+      --text "Hello, this is a test of my custom trained voice." \
+      --output_wav_path ./output_sample.wav
+      # Arguments optionnels/dépendants du framework ci-dessous :
+      # --speaker_id "main_speaker"  # Nécessaire pour les modèles multi-locuteurs
+      # --device "cuda"              # Pour spécifier l'utilisation du GPU (souvent par défaut)
+    ```
+-   **Arguments clés :**
+    *   `--config` ou `-c` : Chemin vers le fichier de configuration d'entraînement.
+    *   `--checkpoint_path` ou `--model_path` ou `-m` : Chemin vers le fichier de checkpoint du modèle.
+    *   `--text` ou `-t` : La phrase d'entrée que vous souhaitez synthétiser. Pensez à la mettre entre guillemets.
+    *   `--output_wav_path` ou `--out_path` ou `-o` : Le chemin et le nom de fichier souhaités pour le fichier WAV généré.
+    *   `--speaker_id` ou `--spk` : **Requis** si vous avez entraîné un modèle multi-locuteurs. Fournissez l'identifiant de locuteur exact utilisé dans vos fichiers manifest pour la voix souhaitée. Pour les modèles à locuteur unique, cela peut être optionnel ou ignoré.
+    *   `--device` : Souvent optionnel, par défaut `cuda` si disponible, sinon `cpu`. L'inférence est bien plus rapide sur GPU.
+
+-   **Exécution :** Lancez la commande. Elle chargera le modèle, traitera le texte, générera la forme d'onde audio et la sauvegardera dans le fichier de sortie spécifié. Écoutez le fichier WAV de sortie pour vérifier la qualité.
+
+### 7.3. Inférence par lots (Synthèse à partir d'un fichier)
+
+-   **Objectif :** Générer de l'audio pour plusieurs phrases listées dans un fichier texte, en sauvegardant chacune dans un fichier WAV distinct.
+-   **Préparer le fichier d'entrée :** Créez un fichier texte brut (par exemple, `sentences.txt`) où chaque ligne contient une phrase que vous souhaitez synthétiser :
+    ```text
+    Ceci est la première phrase.
+    Voici une autre phrase à synthétiser.
+    Le modèle devrait gérer différents signes de ponctuation, comme les questions ?
+    Et aussi les exclamations !
+    ```
+-   **Structure de la commande :** De nombreux frameworks fournissent un script séparé ou des arguments spécifiques pour le traitement par lots.
+
+    ```bash
+    # Exemple de commande (le nom du script et les arguments peuvent varier) :
+    python inference_batch.py \
+      --config ../checkpoints/my_yoruba_voice_run1/config.yaml \
+      --checkpoint_path ../checkpoints/my_yoruba_voice_run1/best_model.pth \
+      --input_file sentences.txt \
+      --output_dir ./generated_batch_audio/
+      # Arguments optionnels/dépendants du framework ci-dessous :
+      # --speaker_id "main_speaker"  # Nécessaire pour les modèles multi-locuteurs
+      # --device "cuda"
+    ```
+-   **Arguments clés :**
+    *   `--input_file` ou `--text_file` : Chemin vers le fichier texte contenant les phrases (une par ligne).
+    *   `--output_dir` ou `--out_dir` : Chemin vers le répertoire où les fichiers WAV générés doivent être sauvegardés. Assurez-vous que ce répertoire existe ou que le script le crée. Les noms des fichiers de sortie sont souvent basés sur le numéro de ligne ou le texte d'entrée lui-même (par exemple, `output_0.wav`, `output_1.wav`).
+    *   Les autres arguments (`--config`, `--checkpoint_path`, `--speaker_id`, `--device`) sont généralement les mêmes que pour l'inférence d'une phrase unique.
+
+-   **Exécution :** Lancez la commande. Le script itérera sur chaque ligne du fichier d'entrée, synthétisera l'audio et sauvegardera les résultats dans le répertoire de sortie spécifié.
+
+### 7.4. Inférence de modèle multi-locuteurs
+
+-   Comme mentionné ci-dessus, si votre modèle a été entraîné sur des données de plusieurs locuteurs, vous **devez** spécifier quelle voix de locuteur vous souhaitez utiliser pendant l'inférence.
+-   Utilisez l'argument `--speaker_id` (ou son équivalent), en fournissant l'ID exact qui correspond au locuteur souhaité dans vos fichiers manifest d'entraînement (par exemple, `speaker0`, `mary_smith`, `yoruba_male_spk1`).
+-   Si vous omettez l'ID de locuteur pour un modèle multi-locuteurs, le script peut échouer, utiliser par défaut un locuteur spécifique (souvent le locuteur 0) ou produire des résultats moyennés/brouillés.
+
+### 7.5. Contrôles d'inférence avancés (Dépendants du framework)
+
+-   Certains modèles et frameworks TTS avancés offrent des contrôles supplémentaires pendant l'inférence, souvent passés comme arguments en ligne de commande ou paramètres dans une API Python :
+    *   **Débit/Vitesse de parole :** Des arguments comme `--speed` ou `--length_scale` peuvent vous permettre de faire parler la voix plus vite ou plus lentement (par exemple, `1.0` est normal, `<1.0` est plus rapide, `>1.0` est plus lent).
+    *   **Contrôle de la hauteur (Pitch) :** Moins courant, mais certains modèles peuvent autoriser des ajustements de la hauteur.
+    *   **Contrôle du style/de l'émotion :** Si le modèle a été entraîné avec des style tokens ou des capacités d'audio de référence (comme StyleTTS2 ou les modèles avec des style embeddings), vous pourriez fournir des arguments comme `--style_text` ou `--style_wav` pour influencer la prosodie ou l'émotion de la sortie.
+    *   **Réglages du vocoder (si applicable) :** Pour les anciens modèles de type Tacotron2 ou d'autres utilisant des modèles de vocoder séparés (comme HiFi-GAN, MelGAN), il peut y avoir des réglages relatifs au vocoder (par exemple, l'intensité du débruitage).
+    *   **Modèles de diffusion :** Pour les modèles TTS basés sur la diffusion, des paramètres contrôlant le nombre de steps de diffusion (échangeant la qualité contre la vitesse) peuvent être disponibles.
+-   **Consulter la documentation :** Référez-vous toujours à la documentation de votre framework TTS spécifique ou à l'aide du script d'inférence (`python inference.py --help`) pour voir quels contrôles sont disponibles.
+
+### 7.6. Problèmes d'inférence potentiels
+
+-   **CUDA Out-of-Memory (OOM) :** Même si l'entraînement a fonctionné, des phrases très longues lors de l'inférence peuvent consommer plus de mémoire. Essayez des phrases plus courtes ou vérifiez si le framework offre des options de synthèse segmentée. L'exécution sur CPU (`--device cpu`) utilise la RAM système mais est nettement plus lente.
+-   **Incompatibilité modèle/config :** Utiliser un checkpoint avec le mauvais fichier de configuration est une erreur courante, conduisant à des échecs de chargement ou à une sortie parasite. Assurez-vous qu'ils correspondent à la même exécution d'entraînement.
+-   **ID de locuteur incorrect :** Fournir un ID de locuteur inexistant pour les modèles multi-locuteurs provoquera des erreurs.
+-   **Problèmes de qualité (Bruit, Instabilité) :** Si la qualité de sortie est médiocre, revisitez le Guide 1 (Préparation des données) et le Guide 3 (Entraînement du modèle). Cela peut indiquer des problèmes de qualité des données, un entraînement insuffisant ou le choix d'un checkpoint sous-optimal.
+
+---
+
+## 8. Évaluation et déploiement du modèle
+
+### 8.1. Évaluer la qualité d'un modèle TTS
+
+Bien que les tests d'écoute subjectifs soient la référence absolue pour l'évaluation TTS, il existe aussi des métriques objectives qui peuvent aider à quantifier les performances de votre modèle :
+
+#### Métriques d'évaluation objectives
+
+| Métrique | Ce qu'elle mesure | Outils/Implémentation | Interprétation |
+|:-------|:-----------------|:---------------------|:---------------|
+| **MOS (Mean Opinion Score)** | Qualité perçue globale | Des évaluateurs humains notent les échantillons sur une échelle de 1 à 5 | Plus c'est élevé, mieux c'est ; norme du secteur mais nécessite des évaluateurs humains |
+| **PESQ (Perceptual Evaluation of Speech Quality)** | Qualité audio comparée à une référence | Disponible en Python via `pypesq` | Plage : -0,5 à 4,5 ; plus c'est élevé, mieux c'est |
+| **STOI (Short-Time Objective Intelligibility)** | Intelligibilité de la parole | Disponible en Python via `pystoi` | Plage : 0 à 1 ; plus c'est élevé, mieux c'est |
+| **Taux d'erreur sur les caractères/mots (CER/WER)** | Intelligibilité via ASR | Exécuter l'ASR sur la parole synthétisée et comparer au texte d'entrée | Plus c'est bas, mieux c'est ; mesure si les mots sont prononcés correctement |
+| **Mel Cepstral Distortion (MCD)** | Distance spectrale par rapport à la référence | Implémentation personnalisée avec librosa | Plus c'est bas, mieux c'est ; généralement 2-8 pour les systèmes TTS |
+| **F0 RMSE** | Précision de la hauteur | Implémentation personnalisée avec librosa | Plus c'est bas, mieux c'est ; mesure la précision du contour de hauteur |
+| **Voicing Decision Error** | Précision voisé/non voisé | Implémentation personnalisée | Plus c'est bas, mieux c'est ; mesure si la parole/le silence est correctement placé |
+
+#### Approche pratique d'évaluation
+
+1. **Préparer le jeu de test** : Créez un ensemble de phrases de test variées non vues pendant l'entraînement
+   ```
+   # Exemple de test_sentences.txt
+   Ceci est une simple phrase déclarative.
+   Est-ce une phrase interrogative ?
+   Ouah ! Ceci est une phrase exclamative !
+   Cette phrase contient des nombres comme 123 et des symboles comme %.
+   Ceci est une phrase bien plus longue qui se poursuit pendant un certain temps, testant la capacité du modèle à maintenir la cohérence et une prosodie correcte sur des énoncés plus longs comportant plusieurs propositions et locutions.
+   ```
+
+2. **Générer les échantillons** : Utilisez votre modèle pour synthétiser la parole de toutes les phrases de test
+
+3. **Réaliser des tests d'écoute** : Faites noter les échantillons par plusieurs auditeurs sur :
+   - Le naturel (échelle de 1 à 5)
+   - La qualité audio/les artefacts (échelle de 1 à 5)
+   - La précision de la prononciation (échelle de 1 à 5)
+   - La similarité du locuteur (échelle de 1 à 5, si vous clonez une voix spécifique)
+
+4. **Implémenter des métriques objectives** : Ce snippet Python montre comment calculer quelques métriques de base :
+
+   ```python
+   import numpy as np
+   import librosa
+   from pesq import pesq
+   from pystoi import stoi
+   import torch
+   from transformers import pipeline
+
+   def evaluate_tts_sample(generated_audio_path, reference_audio_path=None, original_text=None):
+       """Évalue un échantillon TTS à l'aide de diverses métriques."""
+       results = {}
+       
+       # Charge l'audio généré
+       y_gen, sr_gen = librosa.load(generated_audio_path, sr=None)
+       
+       # Statistiques audio de base
+       results["duration"] = librosa.get_duration(y=y_gen, sr=sr_gen)
+       results["rms_energy"] = np.sqrt(np.mean(y_gen**2))
+       
+       # Si l'audio de référence est disponible, calcule les métriques de comparaison
+       if reference_audio_path:
+           y_ref, sr_ref = librosa.load(reference_audio_path, sr=sr_gen)  # Fait correspondre les sampling rates
+           
+           # Assure la même longueur pour la comparaison
+           min_len = min(len(y_gen), len(y_ref))
+           y_gen_trim = y_gen[:min_len]
+           y_ref_trim = y_ref[:min_len]
+           
+           # PESQ (nécessite de l'audio en 16kHz ou 8kHz)
+           if sr_gen in [8000, 16000]:
+               try:
+                   results["pesq"] = pesq(sr_gen, y_ref_trim, y_gen_trim, 'wb')
+               except Exception as e:
+                   results["pesq"] = f"Error: {str(e)}"
+           else:
+               results["pesq"] = "Requires 8kHz or 16kHz audio"
+           
+           # STOI
+           try:
+               results["stoi"] = stoi(y_ref_trim, y_gen_trim, sr_gen, extended=False)
+           except Exception as e:
+               results["stoi"] = f"Error: {str(e)}"
+       
+       # Si le texte original est disponible, effectue l'ASR et calcule WER/CER
+       if original_text:
+           try:
+               # Charge le modèle ASR (nécessite transformers et torch)
+               asr = pipeline("automatic-speech-recognition", model="openai/whisper-small")
+               
+               # Transcrit l'audio généré
+               transcription = asr(generated_audio_path)["text"].strip().lower()
+               original_text = original_text.strip().lower()
+               
+               results["transcription"] = transcription
+               results["original_text"] = original_text
+               
+               # Calcul simple du taux d'erreur sur les caractères
+               def cer(ref, hyp):
+                   ref, hyp = ref.lower(), hyp.lower()
+                   return levenshtein_distance(ref, hyp) / len(ref)
+               
+               def levenshtein_distance(s1, s2):
+                   if len(s1) < len(s2):
+                       return levenshtein_distance(s2, s1)
+                   if len(s2) == 0:
+                       return len(s1)
+                   previous_row = range(len(s2) + 1)
+                   for i, c1 in enumerate(s1):
+                       current_row = [i + 1]
+                       for j, c2 in enumerate(s2):
+                           insertions = previous_row[j + 1] + 1
+                           deletions = current_row[j] + 1
+                           substitutions = previous_row[j] + (c1 != c2)
+                           current_row.append(min(insertions, deletions, substitutions))
+                       previous_row = current_row
+                   return previous_row[-1]
+               
+               results["character_error_rate"] = cer(original_text, transcription)
+           except Exception as e:
+               results["asr_error"] = str(e)
+       
+       return results
+   ```
+
+### 8.2. Déployer des modèles TTS
+
+Une fois votre modèle entraîné et évalué, vous pourriez vouloir le déployer pour une utilisation pratique. Voici quelques options de déploiement :
+
+#### Considérations pour le déploiement en production
+
+Lors du passage de l'expérimentation au déploiement en production, prenez en compte ces facteurs importants :
+
+1. **Optimisation du modèle**
+   - **Quantification** : Réduire la précision du modèle de FP32 à FP16 ou INT8 pour diminuer la taille et augmenter la vitesse d'inférence
+   - **Élagage (Pruning)** : Supprimer les poids inutiles pour créer des modèles plus petits et plus rapides
+   - **Distillation des connaissances** : Entraîner un modèle « élève » plus petit pour imiter votre modèle « enseignant » plus grand
+   - **Conversion ONNX** : Convertir votre modèle PyTorch/TensorFlow au format ONNX pour de meilleures performances multiplateformes
+
+2. **Optimisation de la latence**
+   - **Traitement par lots** : Pour les applications non temps réel, traiter plusieurs requêtes par lots
+   - **Synthèse en streaming** : Pour les applications temps réel, implémenter un traitement segment par segment
+   - **Mise en cache** : Mettre en cache les phrases ou séquences de phonèmes fréquemment demandées
+   - **Accélération matérielle** : Utiliser GPU/TPU pour le traitement parallèle ou du matériel spécialisé comme NVIDIA TensorRT
+
+3. **Évolutivité (Scalabilité)**
+   - **Conteneurisation** : Empaqueter votre modèle et ses dépendances dans des conteneurs Docker
+   - **Kubernetes** : Orchestrer plusieurs conteneurs pour la haute disponibilité et l'équilibrage de charge
+   - **Mise à l'échelle automatique (Auto-scaling)** : Ajuster automatiquement les ressources en fonction de la demande
+   - **Systèmes de file d'attente** : Implémenter des files d'attente de requêtes (RabbitMQ, Kafka) pour gérer les pics de trafic
+
+4. **Surveillance et maintenance**
+   - **Métriques de performance** : Suivre la latence, le débit, les taux d'erreur et l'utilisation des ressources
+   - **Surveillance de la qualité** : Échantillonner et évaluer périodiquement la qualité de sortie
+   - **Tests A/B** : Comparer différentes versions de modèle en production
+   - **Entraînement continu** : Mettre en place des pipelines pour réentraîner les modèles avec de nouvelles données
+
+#### Exemple d'architecture de déploiement en production
+
+```
+[Applications clientes] → [Équilibreur de charge] → [Passerelle API]
+                                             ↓
+[Validation des requêtes] → [Limitation de débit] → [Authentification]
+                                             ↓
+[File d'attente des requêtes] → [Pods de workers TTS (Kubernetes)] → [Cache audio]
+                         ↓                              ↑
+                  [Conteneur du modèle TTS]             |
+                         ↓                              |
+                  [Post-traitement audio] → [Stockage audio]
+```
+
+#### Options de déploiement local
+
+1. **Interface en ligne de commande** : L'approche la plus simple consiste à créer un script qui encapsule le code d'inférence :
+
+   ```python
+   # tts_cli.py
+   import argparse
+   import os
+   import torch
+   
+   # Importez ici vos modules spécifiques au modèle
+   # from your_tts_framework import load_model, synthesize_text
+   
+   def main():
+       parser = argparse.ArgumentParser(description="Text-to-Speech CLI")
+       parser.add_argument("--text", type=str, required=True, help="Text to synthesize")
+       parser.add_argument("--model", type=str, required=True, help="Path to model checkpoint")
+       parser.add_argument("--config", type=str, required=True, help="Path to model config")
+       parser.add_argument("--output", type=str, default="output.wav", help="Output audio file path")
+       parser.add_argument("--speaker", type=str, default=None, help="Speaker ID for multi-speaker models")
+       args = parser.parse_args()
+       
+       # Charge le modèle (l'implémentation dépend de votre framework)
+       model = load_model(args.model, args.config)
+       
+       # Synthétise la parole
+       audio = synthesize_text(model, args.text, speaker_id=args.speaker)
+       
+       # Sauvegarde l'audio
+       save_audio(audio, args.output)
+       print(f"Audio saved to {args.output}")
+   
+   if __name__ == "__main__":
+       main()
+   ```
+
+2. **Interface web simple** : Créez une interface web basique avec Flask ou Gradio :
+
+   ```python
+   # app.py (exemple Flask)
+   from flask import Flask, request, send_file, render_template
+   import os
+   import torch
+   import uuid
+   
+   # Importez ici vos modules spécifiques au modèle
+   # from your_tts_framework import load_model, synthesize_text
+   
+   app = Flask(__name__)
+   
+   # Charge le modèle au démarrage (pour une inférence plus rapide)
+   MODEL_PATH = "path/to/best_model.pth"
+   CONFIG_PATH = "path/to/config.yaml"
+   model = load_model(MODEL_PATH, CONFIG_PATH)
+   
+   @app.route('/')
+   def index():
+       return render_template('index.html')
+   
+   @app.route('/synthesize', methods=['POST'])
+   def synthesize():
+       text = request.form['text']
+       speaker_id = request.form.get('speaker_id', None)
+       
+       # Génère un nom de fichier unique
+       output_file = f"static/audio/{uuid.uuid4()}.wav"
+       os.makedirs(os.path.dirname(output_file), exist_ok=True)
+       
+       # Synthétise la parole
+       audio = synthesize_text(model, text, speaker_id=speaker_id)
+       
+       # Sauvegarde l'audio
+       save_audio(audio, output_file)
+       
+       return {'audio_path': output_file}
+   
+   if __name__ == '__main__':
+       app.run(host='0.0.0.0', port=5000, debug=True)
+   ```
+
+3. **Interface Gradio** (Encore plus simple) :
+
+   ```python
+   import gradio as gr
+   import torch
+   
+   # Importez ici vos modules spécifiques au modèle
+   # from your_tts_framework import load_model, synthesize_text
+   
+   # Charge le modèle
+   MODEL_PATH = "path/to/best_model.pth"
+   CONFIG_PATH = "path/to/config.yaml"
+   model = load_model(MODEL_PATH, CONFIG_PATH)
+   
+   def tts_function(text, speaker_id=None):
+       # Synthétise la parole
+       audio = synthesize_text(model, text, speaker_id=speaker_id)
+       sampling_rate = 22050  # Ajustez selon la fréquence de votre modèle
+       return (sampling_rate, audio)
+   
+   # Crée l'interface Gradio
+   iface = gr.Interface(
+       fn=tts_function,
+       inputs=[
+           gr.Textbox(lines=3, placeholder="Enter text to synthesize..."),
+           gr.Dropdown(choices=["speaker1", "speaker2"], label="Speaker", visible=True)  # Pour les modèles multi-locuteurs
+       ],
+       outputs=gr.Audio(type="numpy"),
+       title="Text-to-Speech Demo",
+       description="Enter text and generate speech using a custom TTS model."
+   )
+   
+   iface.launch(server_name="0.0.0.0", server_port=7860)
+   ```
+
+#### Options de déploiement cloud
+
+Pour une utilisation en production, envisagez ces options :
+
+1. **Hugging Face Spaces** : Téléversez votre modèle sur Hugging Face et créez une application Gradio ou Streamlit
+2. **API REST** : Encapsulez votre modèle dans une application FastAPI ou Flask et déployez-la sur des services cloud
+3. **Fonctions serverless** : Pour les modèles légers, déployez en tant que fonctions serverless (AWS Lambda, Google Cloud Functions)
+4. **Conteneurs Docker** : Empaquetez votre modèle et ses dépendances dans un conteneur Docker pour un déploiement cohérent
+
+#### Optimisation des performances
+
+Pour améliorer la vitesse et l'efficacité de l'inférence :
+
+1. **Quantification du modèle** : Convertir les poids du modèle en précision inférieure (FP16 ou INT8)
+   ```python
+   # Exemple de conversion FP16 avec PyTorch
+   model = model.half()  # Convertir en FP16
+   ```
+
+2. **Élagage du modèle (Pruning)** : Supprimer les poids inutiles pour créer des modèles plus petits
+3. **Conversion ONNX** : Convertir les modèles PyTorch au format ONNX pour une inférence plus rapide
+   ```python
+   # Exemple d'export ONNX
+   import torch.onnx
+   
+   # Exporte le modèle
+   torch.onnx.export(model,               # modèle en cours d'exécution
+                     dummy_input,         # entrée du modèle (ou un tuple pour plusieurs entrées)
+                     "model.onnx",        # où sauvegarder le modèle
+                     export_params=True,  # stocke les poids des paramètres entraînés dans le fichier du modèle
+                     opset_version=11,    # la version ONNX vers laquelle exporter le modèle
+                     do_constant_folding=True)  # optimisation
+   ```
+
+4. **Traitement par lots** : Traiter plusieurs entrées textuelles à la fois pour un débit plus élevé
+5. **Mise en cache** : Mettre en cache les sorties fréquemment demandées pour éviter une régénération
+
+Maintenant que vous pouvez générer de la parole à l'aide de votre modèle entraîné, l'étape logique suivante consiste à organiser correctement les fichiers de votre modèle pour une utilisation future, un partage ou un déploiement.
+
+**Étape suivante :** [Packaging et partage](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+[Retour en haut](#top){: .btn .btn-primary}

--- a/languages/fr/guides/5_PACKAGING_AND_SHARING.md
+++ b/languages/fr/guides/5_PACKAGING_AND_SHARING.md
@@ -1,0 +1,129 @@
+# Guide 5 : Packaging et partage de votre modèle TTS
+
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape précédente : Inférence](./4_INFERENCE.md){: .btn .btn-primary} |  | [Étape suivante : Dépannage et ressources](./6_TROUBLESHOOTING_AND_RESOURCES.md){: .btn .btn-primary} | 
+
+
+Vous avez entraîné un modèle et pouvez générer de la parole avec lui. Félicitations ! Pour garantir que votre modèle sera utilisable à l'avenir (par vous-même ou par d'autres) et pour faciliter la reproductibilité, un packaging et une documentation appropriés sont essentiels.
+
+---
+
+## 9. Packaging de votre modèle entraîné
+
+Considérez votre modèle entraîné non pas comme un simple fichier `.pth`, mais comme un package complet contenant tout ce qui est nécessaire pour le comprendre et l'utiliser.
+
+### 9.1. Organiser les fichiers de votre modèle
+
+Créez une structure de répertoires propre et autonome pour chaque modèle entraîné distinct ou version significative. Cela facilite la recherche ultérieure de tous les éléments.
+
+**Exemple de structure :**
+
+```
+my_tts_model_packages/
+└── yoruba_male_v1.0/         # Nom descriptif de ce package de modèle
+    ├── checkpoints/          # Répertoire des poids du modèle
+    │   ├── best_model.pth    # Checkpoint avec la validation loss la plus basse (ou la meilleure qualité perçue)
+    │   └── last_model.pth    # Checkpoint de la toute fin de l'entraînement (optionnel, mais parfois utile)
+    │
+    ├── config.yaml           # Le fichier de configuration EXACT utilisé pour entraîner CE checkpoint
+    │
+    ├── training_info.md      # Optionnel : un fichier avec des logs/notes d'entraînement détaillés
+    │   ├── train_list.txt    # Copie du fichier manifest d'entraînement utilisé
+    │   └── val_list.txt      # Copie du fichier manifest de validation utilisé
+    │
+    ├── samples/              # Répertoire avec des exemples audio générés par ce modèle
+    │   ├── sample_short_sentence.wav
+    │   ├── sample_question.wav
+    │   └── sample_longer_paragraph.wav
+    │
+    └── README.md             # Essentiel : documentation lisible par l'humain pour ce package de modèle spécifique
+```
+
+**Composants clés expliqués :**
+
+*   **`checkpoints/`** : Contient les poids réels du modèle. Incluez toujours le checkpoint jugé « meilleur » (que ce soit par la loss ou par les tests d'écoute). Inclure le checkpoint final est aussi une bonne pratique.
+*   **`config.yaml` (ou `.json`)** : Absolument critique. Ce fichier définit l'architecture et les paramètres du modèle requis pour charger et utiliser correctement le checkpoint. Sans lui, le checkpoint est souvent inutilisable. Assurez-vous qu'il s'agit de la config *exacte* utilisée pour les checkpoints inclus.
+*   **`training_info.md` / Manifests (Optionnel mais recommandé) :** Conserver les manifests aide à suivre exactement sur quelles données le modèle a été entraîné. Un `training_info.md` peut contenir des notes sur l'exécution d'entraînement (durée, matériel utilisé, métriques finales, observations).
+*   **`samples/`** : Incluez quelques exemples audio variés générés par le `best_model.pth`. Cela démontre rapidement l'identité vocale, la qualité et les caractéristiques du modèle.
+*   **`README.md`** : Le manuel d'utilisation de ce package de modèle spécifique. Voir la section suivante.
+
+### 9.2. Rédiger un bon README.md de modèle
+
+Ce README est spécifique à *ce package de modèle*, et non au guide global du projet. Il doit indiquer à quiconque (y compris à vous-même dans le futur) tout ce qu'il faut savoir pour utiliser le modèle.
+
+**Modèle minimal :**
+
+```markdown
+# Package de modèle TTS : Voix masculine yoruba v1.0
+
+## Description du modèle
+- **Voix :** Voix masculine adulte et claire parlant le yoruba.
+- **Qualité des données source :** Entraîné sur environ 25 heures d'enregistrements de diffusion radio propres.
+- **Langue(s) :** Yoruba (principalement). Peut avoir une gestion limitée des emprunts anglais selon les données d'entraînement.
+- **Style d'élocution :** Style formel, narratif/de diffusion.
+- **Architecture du modèle :** [Préciser le framework/l'architecture, par exemple StyleTTS2, VITS]
+- **Version :** 1.0
+
+## Détails de l'entraînement
+- **Basé sur :** Affiné à partir de [préciser le modèle de base, par exemple un modèle LibriTTS pré-entraîné] OU entraîné à partir de zéro.
+- **Données d'entraînement :** Voir les fichiers `train_list.txt` et `val_list.txt` inclus. Nombre total d'heures : ~25h.
+- **Configuration d'entraînement clé :** Voir le fichier `config.yaml` inclus.
+- **Taux d'échantillonnage :** 22050 Hz (l'audio d'entrée doit correspondre à ce taux pour certains frameworks).
+- **Temps d'entraînement :** Environ 48 heures sur 1x NVIDIA RTX 3090.
+- **Informations sur le checkpoint :** `best_model.pth` sélectionné en fonction de la validation loss la plus basse à l'étape [XXXXX].
+
+## Comment l'utiliser pour l'inférence
+1.  **Prérequis :** Assurez-vous d'avoir installé le framework [préciser le nom du framework TTS, par exemple StyleTTS2], compatible avec cette version du modèle.
+2.  **Configuration :** Utilisez le fichier `config.yaml` inclus.
+3.  **Checkpoint :** Chargez le fichier `checkpoints/best_model.pth`.
+4.  **Texte d'entrée :** Fournissez un texte brut en entrée. Une normalisation du texte correspondant aux données d'entraînement (par exemple, l'expansion des nombres) peut améliorer les résultats.
+5.  **Identifiant de locuteur (le cas échéant) :** Il s'agit d'un modèle à locuteur unique. Utilisez l'identifiant de locuteur `[préciser l'ID utilisé, par exemple main_speaker]` si le framework l'exige, sinon il peut ne pas être nécessaire.
+6.  **Sortie attendue :** L'audio sera généré à un taux d'échantillonnage de 22050 Hz.
+
+## Échantillons audio
+Écoutez des exemples générés par ce modèle :
+- [Phrase courte](./samples/sample_short_sentence.wav)
+- [Question](./samples/sample_question.wav)
+- [Paragraphe plus long](./samples/sample_longer_paragraph.wav)
+
+## Limitations connues / Notes
+- Les performances peuvent se dégrader sur des textes très différents du domaine de la diffusion radio.
+- Ne modélise pas explicitement les émotions nuancées.
+- [Ajouter toute autre observation pertinente]
+
+## Licence
+- **Poids du modèle :** [Préciser la licence, par exemple CC BY-NC-SA 4.0, usage recherche/non commercial uniquement, licence MIT - Soyez précis !]
+- **Données source :** [Mentionner les restrictions de licence des données source si elles affectent l'utilisation du modèle, par exemple « Entraîné sur des données propriétaires, modèle à usage interne uniquement. »] **Consultez la licence de vos données d'entraînement !**
+```
+
+### 9.3. Conseils de versionnement des modèles
+
+Traitez vos modèles entraînés comme des versions logicielles.
+
+*   **Utiliser le versionnement sémantique (Recommandé) :** Utilisez des noms comme `model_v1.0`, `model_v1.1`, `model_v2.0`.
+    *   Incrémentez la version PATCH (v1.0 -> v1.0.1) pour des corrections mineures/réentraînements avec les mêmes données/config.
+    *   Incrémentez la version MINEURE (v1.0 -> v1.1) pour des améliorations, un réentraînement avec plus de données, des ajustements de config significatifs.
+    *   Incrémentez la version MAJEURE (v1.0 -> v2.0) pour des changements d'architecture majeurs ou un réentraînement complet avec des données/objectifs fondamentaux différents.
+*   **Mettre à jour les README :** Lors de la création d'une nouvelle version, mettez à jour son README pour refléter les changements par rapport à la version précédente.
+*   **Conserver les anciennes versions :** N'éliminez pas immédiatement les versions antérieures. Parfois, un modèle précédent peut être plus performant sur certains types de texte, ou vous pourriez avoir besoin de revenir en arrière si une nouvelle version introduit des régressions. Si le stockage le permet, archivez-les.
+
+### 9.4. Considérations relatives au partage et à la distribution
+
+Si vous prévoyez de partager votre modèle :
+
+*   **Packaging :** Créez une archive compressée (par exemple, `.zip`, `.tar.gz`) de l'ensemble du répertoire du package de modèle (contenant les checkpoints, la config, le README, les échantillons, etc.).
+*   **Plateformes d'hébergement :**
+    *   **Hugging Face Hub (Models) :** Excellente plateforme pour partager des modèles, comprend le versionnement, les model cards (utilisez le contenu de votre README !) et potentiellement des widgets d'inférence. Facile pour les autres à découvrir et utiliser.
+    *   **GitHub Releases :** Adapté aux modèles plus petits, attachez l'archive zip à un tag de release dans le dépôt de votre projet.
+    *   **Stockage cloud (Google Drive, Dropbox, S3) :** Simple pour le partage direct, mais moins facile à découvrir et dépourvu de fonctionnalités de versionnement. Assurez-vous que les permissions des liens sont correctement définies.
+*   **Licences (CRITIQUE) :**
+    *   **Votre modèle :** Choisissez une licence pour les *poids* du modèle que vous distribuez (par exemple, MIT, Apache 2.0 pour les licences permissives ; CC BY-NC-SA pour un partage non commercial).
+    *   **Dépendance aux données :** **Point crucial : la licence de vos données d'entraînement dicte souvent la manière dont vous pouvez licencier votre modèle entraîné.** Si vous avez entraîné sur des données avec une licence non commerciale, vous ne pouvez généralement pas publier votre modèle sous une licence commerciale permissive. Si vous avez entraîné sur des données protégées par le droit d'auteur sans autorisation, vous ne pouvez probablement pas partager le modèle publiquement du tout. **Vérifiez toujours les licences de vos sources de données.**
+    *   **Licence du framework :** Le code du framework TTS lui-même possède sa propre licence, distincte de celle de votre modèle.
+    *   **Indiquer clairement les conditions d'utilisation :** Utilisez le `README.md` au sein de votre package de modèle pour indiquer clairement l'utilisation prévue (par exemple, recherche uniquement, non commercial, libre pour tout usage) et les conditions de licence.
+
+---
+
+Un packaging et une documentation appropriés de vos modèles les rendent nettement plus précieux et utilisables, que ce soit pour vos propres projets futurs ou pour la collaboration et le partage au sein de la communauté.
+
+**Étape suivante :** [Dépannage et ressources](./6_TROUBLESHOOTING_AND_RESOURCES.md){: .btn .btn-primary} | 
+[Retour en haut](#top){: .btn .btn-primary}

--- a/languages/fr/guides/6_TROUBLESHOOTING_AND_RESOURCES.md
+++ b/languages/fr/guides/6_TROUBLESHOOTING_AND_RESOURCES.md
@@ -1,0 +1,86 @@
+# Guide 6 : Dépannage et ressources
+
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape précédente : Packaging et partage](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+
+Ce guide fournit des solutions aux problèmes courants rencontrés lors des processus de préparation des données, d'entraînement et d'inférence TTS, ainsi qu'une liste d'outils et de ressources utiles.
+
+---
+
+## 8. Dépannage des problèmes courants
+
+Référez-vous à ce tableau lorsque vous rencontrez des problèmes. Les problèmes sont souvent liés à la qualité des données ou aux réglages de configuration.
+
+| Catégorie de problème     | Problème spécifique                                 | Causes possibles et solutions                                                                                                                                                            | Guide(s) pertinent(s)                                                             |
+| :----------------------- | :-------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
+| **Préparation des données** | Erreurs de script pendant le découpage/la normalisation | Chemins de fichiers incorrects ; format audio initialement non pris en charge ; dépendances manquantes (`ffmpeg`, `pydub`) ; audio extrêmement bruyant/silencieux perturbant la détection de silence. **Vérifiez les chemins du script, installez les dépendances, ajustez les paramètres de silence.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md)                                  |
+|                          | La génération du manifest ignore de nombreux fichiers | Noms de fichiers incohérents entre audio et transcriptions ; fichiers de transcription vides ; chemins incorrects spécifiés dans le script ; encodage non-UTF8 dans les fichiers texte. **Vérifiez les noms, vérifiez les chemins, assurez-vous que les fichiers texte ont du contenu et un encodage UTF-8.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md)                                  |
+| **Configuration de l'entraînement** | Échec de `pip install`                    | Bibliothèques système manquantes (par ex. `libsndfile-dev`) ; version de Python incompatible ; problèmes réseau ; conflits entre paquets. **Lisez attentivement les messages d'erreur, installez les libs système, utilisez un environnement virtuel, vérifiez la documentation du framework pour les prérequis.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md)                                    |
+|                          | PyTorch `cuda is not available`                   | Version de PyTorch incorrecte installée (CPU uniquement) ; version du pilote NVIDIA/toolkit CUDA incompatible ; GPU non détecté par l'OS. **Réinstallez PyTorch avec la bonne version de CUDA depuis le site officiel, mettez à jour les pilotes.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md)                                    |
+| **Exécution de l'entraînement** | Erreur CUDA Out-of-Memory (OOM) au démarrage/pendant l'entraînement | `batch_size` trop grand pour la VRAM du GPU ; architecture du modèle trop complexe ; fuite de mémoire dans le framework/code personnalisé. **Réduisez le `batch_size` dans la config ; activez l'Automatic Mixed Precision (AMP/FP16) si disponible ; vérifiez les mises à jour du framework.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | La training loss est `NaN` ou diverge (explose)   | Learning rate trop élevé ; gradients instables ; mauvais batch de données (par ex. audio/texte corrompu) ; problèmes de précision numérique. **Baissez le learning rate ; vérifiez la qualité des données ; utilisez le gradient clipping (souvent activé par défaut) ; essayez le FP32 si vous utilisez AMP/FP16.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | La training loss stagne (ne diminue pas)          | Learning rate trop bas ; mauvaise qualité/variété des données ; modèle bloqué dans un minimum local ; configuration du modèle incorrecte. **Augmentez légèrement le learning rate ; améliorez/augmentez les données ; vérifiez la config (surtout les paramètres audio) ; essayez un autre optimiseur.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | La validation loss augmente tandis que la training loss diminue (Overfitting) | Modèle mémorisant les données d'entraînement ; jeu de validation insuffisant/non représentatif ; entraînement trop long. **Arrêtez l'entraînement tôt (selon la meilleure val loss) ; ajoutez des données d'entraînement plus variées ; utilisez la régularisation (weight decay, dropout - vérifiez la config) ; améliorez le jeu de validation.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+| **Qualité de l'inférence** | La sortie sonne robotique/monotone                | Entraînement insuffisant ; mauvaise prosodie dans les données d'entraînement ; limitations de l'architecture du modèle ; problèmes de normalisation du texte. **Entraînez plus longtemps ; améliorez la variété/qualité des données ; essayez une autre architecture de modèle ; assurez-vous que le texte est bien ponctué/normalisé.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+|                          | La sortie est bruyante/brouillée/inintelligible   | Mauvaise qualité des données (bruit incorporé) ; le modèle n'a pas convergé ; incompatibilité entre la config d'entraînement et la config/le checkpoint d'inférence ; sampling rate incorrect utilisé en inférence. **Nettoyez rigoureusement les données d'entraînement ; entraînez plus longtemps ; assurez une correspondance EXACTE config/checkpoint ; vérifiez les paramètres audio.** | Tous les guides                                                                   |
+|                          | La sortie sonne comme le mauvais locuteur (fine-tuning) | Modèle pré-entraîné non chargé correctement ; learning rate trop élevé initialement ; données/steps de fine-tuning insuffisants ; incompatibilité d'ID de locuteur. **Vérifiez `pretrained_model_path` et `ignore_layers` dans la config ; utilisez un LR plus bas pour le fine-tuning ; entraînez plus longtemps ; vérifiez l'ID de locuteur.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+|                          | L'inférence se coupe trop tôt ou parle trop vite/lentement | Limitation du modèle (prédiction de durée) ; réglage d'inférence limitant la longueur de sortie maximale ; paramètre length scale/vitesse incorrect. **Vérifiez la documentation du framework pour les réglages de max decoder steps / max length ; ajustez les paramètres de contrôle de la vitesse.** | [4_INFERENCE.md](./4_INFERENCE.md)                                                |
+| **Utilisation du modèle** | Impossible de charger le fichier de checkpoint    | Téléchargement/fichier corrompu ; utilisation d'un checkpoint avec une version de framework ou un fichier de config incompatible ; chemin de fichier incorrect. **Retéléchargez/vérifiez l'intégrité du fichier ; utilisez la bonne config ; assurez-vous que la version du framework correspond à celle utilisée pour l'entraînement ; vérifiez le chemin.** | [5_PACKAGING_AND_SHARING.md](./5_PACKAGING_AND_SHARING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+
+---
+
+## 10. Ressources et outils utiles
+
+Cette liste comprend des logiciels, bibliothèques et communautés utiles pour les projets TTS.
+
+### Traitement et analyse audio :
+
+*   **[Audacity](https://www.audacityteam.org/) :** Éditeur audio gratuit, open source et multiplateforme. Excellent pour l'inspection manuelle, le nettoyage, l'étiquetage et le traitement basique des fichiers audio.
+*   **[FFmpeg](https://ffmpeg.org/) :** Le couteau suisse en ligne de commande pour la conversion audio/vidéo, le rééchantillonnage, la manipulation des canaux, les changements de format, et bien plus. Essentiel pour scripter des opérations par lots.
+*   **[SoX (Sound eXchange Compiled)](http://sox.sourceforge.net/) ou [Sox - Code source](https://codeberg.org/sox_ng/sox_ng/) :** Utilitaire en ligne de commande pour le traitement audio. Utile pour les effets, la conversion de format et l'obtention d'informations audio (commande `soxi`).
+*   **[pydub](https://github.com/jiaaro/pydub) :** Bibliothèque Python pour une manipulation audio facile (découpage, conversion de format, ajustement du volume, détection de silence). Utilise le backend ffmpeg/libav.
+*   **[librosa](https://librosa.org/doc/latest/index.html) :** Bibliothèque Python pour l'analyse audio avancée, l'extraction de caractéristiques (comme les spectrogrammes mel) et la visualisation. Souvent utilisée en interne par les frameworks TTS.
+*   **[soundfile](https://python-soundfile.readthedocs.io/en/latest/) :** Bibliothèque Python pour la lecture/écriture de fichiers audio, basée sur libsndfile. Prend en charge de nombreux formats.
+*   **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm) :** Bibliothèque Python pour la normalisation de la sonie (LUFS), généralement préférée à la simple normalisation de crête pour une cohérence perçue.
+
+### Transcription (ASR) :
+
+*   **[OpenAI Whisper](https://github.com/openai/whisper) :** Modèle ASR open source de haute qualité, prend en charge de nombreuses langues. Bonne base de référence, mais la ponctuation nécessite souvent une révision. Peut s'exécuter localement (GPU recommandé) ou via API. Diverses implémentations communautaires existent.
+*   **[Modèles Google Gemini (via API/AI Studio)](https://ai.google.dev/) :** Modèles capables pour la transcription, souvent performants sur un audio clair, potentiellement meilleurs sur des segments pré-découpés. Vérifiez l'API/Studio pour les capacités et tarifs/niveaux gratuits actuels.
+*   **Services ASR cloud :**
+    *   [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text)
+    *   [AWS Transcribe](https://aws.amazon.com/transcribe/)
+    *   [Azure Speech Service](https://azure.microsoft.com/en-us/products/cognitive-services/speech-to-text/)
+    *   *Souvent fiables, paiement à l'usage, peuvent avoir des quotas gratuits initiaux.*
+*   **[Hugging Face Transformers - Modèles ASR](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition) :** Hub pour de nombreux modèles ASR pré-entraînés, y compris des versions affinées de Whisper et d'autres. Explorez les modèles affinés pour des langues spécifiques ou l'amélioration de la ponctuation.
+*   **[ElevenLabs Speech To Text (Scribe)](https://elevenlabs.io/speech-to-text) :** *Service commercial.* Connu pour une très haute précision à la fois en transcription et en ponctuation, mais c'est un service payant qui peut être relativement coûteux comparé aux autres. À envisager si le budget le permet et qu'une précision maximale prête à l'emploi est requise.
+
+### Frameworks et bases de code TTS (Exemples - Recherchez des forks/successeurs actifs) :
+
+*   **[StyleTTS2 (Dépôt de recherche)](https://github.com/yl4579/StyleTTS2) :** Travail influent sur le contrôle du style. Recherchez des forks activement maintenus ayant implémenté des pipelines d'entraînement/inférence.
+*   **[VITS (Dépôt de recherche)](https://github.com/jaywalnut310/vits) :** Architecture bout en bout populaire. De nombreux forks et implémentations existent.
+*   **[Coqui TTS (Archivé)](https://github.com/coqui-ai/TTS) :** Était une bibliothèque très populaire et complète. Bien qu'archivée, sa base de code et ses concepts restent influents. De nombreux forks actifs peuvent exister.
+*   **[ESPnet](https://github.com/espnet/espnet) :** Boîte à outils de traitement de la parole bout en bout, comprenant des recettes TTS pour divers modèles. Davantage orientée recherche.
+*   **Rechercher sur GitHub :** Utilisez des mots-clés comme « TTS », « VITS training », « StyleTTS2 training », « PyTorch TTS » pour trouver des projets actuels.
+
+### Environnement Python et Deep Learning :
+
+*   **[Python](https://www.python.org/) :** Le langage de programmation principal.
+*   **[PyTorch](https://pytorch.org/) :** La principale bibliothèque de deep learning utilisée par la plupart des frameworks TTS modernes.
+*   **[TensorBoard](https://www.tensorflow.org/tensorboard) :** Essentiel pour visualiser la progression de l'entraînement (fonctionne aussi avec PyTorch).
+*   **[pip](https://pip.pypa.io/en/stable/) / [uv](https://github.com/astral-sh/uv) :** Installateurs de paquets Python. `uv` est une alternative plus récente, souvent bien plus rapide.
+*   **[conda](https://docs.conda.io/en/latest/) / [venv](https://docs.python.org/3/library/venv.html) :** Outils pour créer des environnements Python isolés.
+*   **[Git](https://git-scm.com/) :** Système de contrôle de version, essentiel pour cloner des dépôts et gérer le code.
+*   **[Hugging Face Hub](https://huggingface.co/) :** Plateforme pour partager des modèles (y compris TTS), des jeux de données et du code.
+
+### Communautés :
+
+*   **GitHub Discussions/Issues des frameworks TTS :** Consultez le dépôt spécifique que vous utilisez pour les questions et réponses de la communauté.
+*   **Serveurs Discord :** De nombreuses communautés IA/ML (comme LAION, EleutherAI, les serveurs de frameworks spécifiques) ont des canaux dédiés au TTS.
+*   **Reddit :** Des subreddits comme r/SpeechSynthesis, r/MachineLearning.
+
+---
+
+Ceci conclut la série principale de guides. N'oubliez pas que la création de bons modèles TTS implique souvent une itération : revisiter la préparation des données ou ajuster les paramètres d'entraînement en fonction des résultats est une pratique courante. Bonne chance !
+
+---
+**Navigation :** [README principal]({{ site.baseurl }}/languages/fr/){: .btn .btn-primary} | [Étape précédente : Packaging et partage](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | [Retour en haut](#top){: .btn .btn-primary}

--- a/languages/it/README.md
+++ b/languages/it/README.md
@@ -1,0 +1,144 @@
+# Guida Universale all'Addestramento di Modelli TTS e alla Preparazione dei Dataset
+
+## Lingue Disponibili
+
+- [English](../../README.md) (Originale)
+- [Español](../es/README.md)
+- [Français](../fr/README.md)
+- **Italiano** (Corrente)
+- [Български](../bg/README.md)
+
+*Vuoi contribuire con una traduzione? Consulta la [Guida alla Traduzione](../../README.md#translation-guide) qui sotto.*
+
+## Introduzione
+
+Benvenuto! Questa guida completa fornisce un processo universale per preparare i tuoi dataset vocali e addestrare un modello Text-to-Speech (TTS) personalizzato. Che tu abbia un piccolo dataset (ad esempio 10 ore) o uno più grande (oltre 100 ore), questi passaggi ti aiuteranno a organizzare i dati correttamente e a navigare il processo di addestramento per la maggior parte dei framework TTS moderni.
+
+**Obiettivo:** Metterti in grado di effettuare il fine-tuning o di addestrare un modello TTS su una voce o lingua specifica utilizzando le tue coppie audio-testo.
+
+**Cosa Copre Questa Guida:**
+Questa guida è suddivisa in diverse parti, che coprono l'intero flusso di lavoro dalla pianificazione all'utilizzo del modello addestrato:
+
+1.  **Pianificazione:** Considerazioni iniziali prima di avviare il tuo progetto.
+2.  **Preparazione dei Dati:** Acquisizione, elaborazione e strutturazione dei dati audio e testuali.
+3.  **Configurazione dell'Addestramento:** Preparazione dell'ambiente e configurazione dei parametri di addestramento.
+4.  **Addestramento del Modello:** Avvio, monitoraggio e fine-tuning del modello TTS.
+5.  **Inferenza:** Utilizzo del modello addestrato per sintetizzare il parlato.
+6.  **Packaging e Condivisione:** Organizzazione e documentazione del modello per usi futuri o distribuzione.
+7.  **Risoluzione dei Problemi e Risorse:** Problemi comuni e strumenti utili.
+
+---
+
+## 0. Prima di Iniziare: Pianificare il Tuo Dataset
+
+Prima di raccogliere i dati, considera questi punti cruciali per assicurarti che il tuo progetto sia ben definito e realizzabile:
+
+1.  **Speaker:** Sarà un singolo speaker o più speaker? I dataset a singolo speaker sono più semplici da cui partire per il fine-tuning o l'addestramento iniziale. I modelli multi-speaker richiedono un attento bilanciamento dei dati e una gestione degli speaker ID.
+2.  **Fonte dei Dati:** Da dove otterrai l'audio? (Audiolibri, podcast, archivi radiofonici, dati vocali registrati professionalmente, le tue registrazioni). **In modo cruciale, assicurati di avere i diritti o le licenze necessarie per utilizzare i dati nell'addestramento dei modelli.**
+3.  **Qualità Audio:** Punta alla qualità più alta possibile. Dai priorità a registrazioni pulite con il minimo di rumore di fondo, riverbero, musica o parlato sovrapposto. La coerenza nelle condizioni di registrazione è molto vantaggiosa.
+4.  **Lingua e Dominio:** Quale lingua o quali lingue parlerà il modello? Qual è lo stile di parlato o il dominio (ad esempio narrazione, conversazione, lettura di notizie)? Il modello darà i risultati migliori su testi simili ai suoi dati di addestramento.
+5.  **Quantità di Dati Target:** Quanti dati prevedi di raccogliere o utilizzare?
+    *   **~1-5 ore:** Potrebbe essere sufficiente per il *cloning* vocale di base se si utilizza un modello pre-addestrato robusto, ma la qualità potrebbe essere limitata.
+    *   **~5-20 ore:** Generalmente considerato il minimo per un *fine-tuning* decente di una voce specifica su un modello pre-addestrato.
+    *   **50-100+ ore:** Migliore per addestrare modelli robusti o per addestrare modelli con minore dipendenza dai pesi pre-addestrati, specialmente per lingue meno comuni.
+    *   **1000+ ore:** Necessarie per addestrare modelli di alta qualità e di uso generale, in gran parte da zero.
+6.  **Sampling Rate:** Decidi in anticipo un sampling rate target (ad esempio 16000 Hz, 22050 Hz, 44100 Hz, 48000 Hz). Sampling rate più alti catturano più dettagli ma richiedono più spazio di archiviazione e potenza di calcolo. **Tutti i tuoi dati di addestramento DEVONO utilizzare in modo coerente il rate scelto.** 22050 Hz è un compromesso comune per molti modelli TTS.
+
+---
+
+## Panoramica del Processo e Navigazione
+
+Questa guida è suddivisa in moduli mirati. Segui i link qui sotto per i passaggi dettagliati di ciascuna fase:
+
+1.  **➡️ [Preparazione dei Dati](./guides/1_DATA_PREPARATION.md)**
+    *   Copre l'acquisizione, la pulizia, la segmentazione, la normalizzazione dell'audio, la trascrizione del testo e la creazione dei file manifest necessari per l'addestramento. Include la fondamentale checklist sulla qualità dei dati.
+
+2.  **➡️ [Configurazione dell'Addestramento](./guides/2_TRAINING_SETUP.md)**
+    *   Ti guida attraverso la configurazione del tuo ambiente Python, l'installazione delle dipendenze (come PyTorch con CUDA), la scelta di un framework TTS e la configurazione dei parametri di addestramento nel tuo file di configurazione.
+
+3.  **➡️ [Addestramento del Modello](./guides/3_MODEL_TRAINING.md)**
+    *   Spiega come avviare lo script di addestramento, monitorarne i progressi (loss, validation), riprendere un addestramento interrotto e fornisce suggerimenti specifici per il fine-tuning di modelli esistenti.
+
+4.  **➡️ [Inferenza](./guides/4_INFERENCE.md)**
+    *   Descrive in dettaglio come utilizzare il checkpoint del modello addestrato per sintetizzare il parlato da nuovo testo, inclusa la singola frase, l'elaborazione batch e le considerazioni multi-speaker.
+
+5.  **➡️ [Packaging e Condivisione](./guides/5_PACKAGING_AND_SHARING.md)**
+    *   Fornisce le best practice per organizzare i file del modello addestrato (checkpoint, config, sample), documentarli con un README, gestire il versioning e prepararli per la condivisione o l'archiviazione.
+
+6.  **➡️ [Risoluzione dei Problemi e Risorse](./guides/6_TROUBLESHOOTING_AND_RESOURCES.md)** 
+    *   Offre soluzioni per i problemi comuni incontrati durante l'addestramento e l'inferenza, ed elenca strumenti, librerie e community esterne utili.
+
+---
+
+## Conclusione
+
+Seguendo queste guide, acquisirai una comprensione completa del flusso di lavoro per la preparazione dei dati e l'addestramento dei tuoi modelli Text-to-Speech. Ricorda che una meticolosa preparazione dei dati è il fondamento di una voce di alta qualità, e il processo di addestramento spesso comporta un perfezionamento iterativo.
+
+Ora, procedi alla sezione pertinente in base a dove ti trovi nel ciclo di vita del tuo progetto. Buona fortuna nella costruzione delle tue voci personalizzate! 🚀
+
+## Contribuire 
+
+I contributi per migliorare questa guida sono benvenuti! Che tu trovi errori di battitura, imprecisioni, abbia suggerimenti per spiegazioni più chiare, voglia aggiungere informazioni su strumenti o framework specifici, o abbia idee per nuove sezioni, il tuo contributo è prezioso.
+
+Sentiti libero di:
+
+*   **Aprire una Issue:** Per segnalare errori, suggerire miglioramenti o discutere potenziali modifiche.
+*   **Inviare una Pull Request:** Per correzioni o aggiunte concrete. Cerca di assicurarti che le tue modifiche siano chiare e in linea con la struttura e il tono generali della guida.
+
+Apprezziamo qualsiasi sforzo per rendere questa guida più accurata, completa e utile per la community!
+
+## Glossario dei Termini Tecnici
+
+Questo glossario spiega i termini tecnici chiave utilizzati nelle guide per aiutare i principianti a comprendere la terminologia:
+
+- **ASR (Automatic Speech Recognition)**: Tecnologia che converte il linguaggio parlato in testo scritto; utilizzata per trascrivere i dati audio.
+- **Batch Size**: Il numero di esempi di addestramento elaborati insieme in un singolo passaggio forward/backward; influisce sulla velocità di addestramento e sull'uso della memoria.
+- **Checkpoint**: Un'istantanea salvata dei pesi di un modello durante o dopo l'addestramento, che consente di riprendere l'addestramento o di utilizzare il modello per l'inferenza.
+- **CUDA**: La piattaforma di calcolo parallelo di NVIDIA che abilita l'accelerazione GPU per i task di deep learning.
+- **dBFS (Decibels relative to Full Scale)**: Un'unità di misura per i livelli audio nei sistemi digitali, dove 0 dBFS rappresenta il livello massimo possibile.
+- **Diffusion Models**: Una classe di modelli generativi che aggiungono e poi rimuovono gradualmente il rumore dai dati; alcuni sistemi TTS recenti utilizzano questo approccio.
+- **FFT (Fast Fourier Transform)**: Un algoritmo che converte i segnali nel dominio del tempo in rappresentazioni nel dominio della frequenza; fondamentale per l'elaborazione audio.
+- **Fine-tuning**: Il processo di prendere un modello pre-addestrato e addestrarlo ulteriormente su un dataset più piccolo e specifico per adattarlo a una nuova voce o lingua.
+- **LUFS (Loudness Units relative to Full Scale)**: Una misura standardizzata della loudness percepita, più rappresentativa dell'udito umano rispetto alle misure di picco.
+- **Manifest File**: Un file di testo che elenca i file audio e le relative trascrizioni, utilizzato per indicare allo script di addestramento dove trovare i dati.
+- **Mel Spectrogram**: Una rappresentazione visiva dell'audio che approssima la percezione uditiva umana utilizzando la scala mel; comunemente usata come rappresentazione intermedia nei sistemi TTS.
+- **Overfitting**: Quando un modello apprende troppo bene i dati di addestramento, incluso il loro rumore e i valori anomali, con il risultato di prestazioni scarse su nuovi dati.
+- **Sampling Rate**: Il numero di campioni audio al secondo (misurato in Hz); rate più alti catturano più dettagli audio ma richiedono più spazio di archiviazione e potenza di elaborazione.
+- **STFT (Short-Time Fourier Transform)**: Una tecnica che determina il contenuto in frequenza di sezioni locali di un segnale mentre questo cambia nel tempo.
+- **TTS (Text-to-Speech)**: Tecnologia che converte il testo scritto in output vocale parlato.
+- **Validation Loss**: Una metrica che misura l'errore di un modello su un dataset di validazione (dati non utilizzati per l'addestramento); aiuta a rilevare l'overfitting.
+- **VRAM (Video RAM)**: Memoria su una scheda grafica; i modelli di deep learning e i loro calcoli intermedi vengono qui memorizzati durante l'addestramento.
+- **Vocoder**: Un componente di alcuni sistemi TTS che converte le feature acustiche (come i mel spectrogram) in forme d'onda (audio effettivo).
+
+## Guida alla Traduzione
+
+Accogliamo con piacere le traduzioni di questa guida per renderla accessibile a un pubblico più ampio. Se desideri contribuire con una traduzione, segui questi passaggi:
+
+1. **Effettua il fork del repository** sul tuo account GitHub
+2. **Crea la struttura di directory necessaria** per la tua lingua:
+   ```
+   languages/[language_code]/
+   ├── README.md
+   └── guides/
+       ├── 1_DATA_PREPARATION.md
+       ├── 2_TRAINING_SETUP.md
+       └── ... (all guide files)
+   ```
+   Dove `[language_code]` è il codice ISO 639-1 a due lettere per la tua lingua (ad esempio `es` per lo spagnolo)
+
+3. **Traduci il contenuto** iniziando dal README.md e poi dai singoli file delle guide
+   - Mantieni la stessa struttura dei file e la stessa formattazione Markdown
+   - Mantieni invariati tutti gli esempi di codice (dovrebbero rimanere in inglese)
+   - Traduci tutto il testo esplicativo, le intestazioni e i commenti
+
+4. **Aggiorna i link di navigazione** in modo che puntino ai file corretti all'interno della directory della tua lingua
+
+5. **Invia una Pull Request** con la tua traduzione
+
+**Note Importanti per i Traduttori:**
+- I termini tecnici possono essere difficili da tradurre. In caso di dubbio, puoi mantenere il termine inglese seguito da una breve spiegazione nella tua lingua.
+- Cerca di mantenere lo stesso tono e lo stesso livello di dettaglio tecnico dell'originale.
+- Se mentre traduci trovi errori o aree di miglioramento nel contenuto originale in inglese, apri una issue separata per affrontarli.
+
+## [Licenza](../../LICENCE.md)
+Il contenuto di questa guida è rilasciato sotto licenza [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/). Sei libero di condividere e adattare il materiale a condizione di fornire un'attribuzione appropriata. Il contenuto è inoltre protetto dal copyright 2025 di AcTePuKc e qualsiasi nuovo contributo sarà soggetto alla stessa licenza.

--- a/languages/it/guides/1_DATA_PREPARATION.md
+++ b/languages/it/guides/1_DATA_PREPARATION.md
@@ -1,0 +1,573 @@
+# Guida 1: Preparazione dei Dati per l'Addestramento TTS
+
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Successivo: Configurazione dell'Addestramento](./2_TRAINING_SETUP.md){: .btn .btn-primary} | 
+
+Questa guida copre la prima fase critica di qualsiasi progetto TTS: la preparazione di dati audio e testuali di alta qualità e formattati correttamente. La qualità del tuo dataset influisce direttamente sulla qualità del tuo modello TTS finale.
+
+---
+
+## 1. Passaggi per la Preparazione del Dataset
+
+Segui questi passaggi in modo sistematico per trasformare l'audio grezzo in un dataset pronto per l'addestramento.
+
+### 1.1. Acquisizione Audio ed Elaborazione Iniziale
+
+-   **Raccogli l'Audio:** Raccogli i tuoi file audio grezzi (i formati comuni includono WAV, MP3, FLAC, OGG, M4A). Assicurati di avere i diritti per utilizzare questo audio.
+-   **Converti in WAV:** La maggior parte dei framework TTS si aspetta il formato WAV. Usa strumenti come `ffmpeg` o librerie audio (`pydub`, `soundfile`) per convertire il tuo audio. Punta a una codifica WAV standard come PCM 16-bit.
+    ```bash
+    # Esempio con ffmpeg per convertire MP3 in WAV
+    ffmpeg -i input_audio.mp3 output_audio.wav
+    ```
+-   **Standardizza i Canali (Mono):** I modelli TTS tipicamente si addestrano su audio a singolo canale (mono). Converti le tracce stereo in mono.
+    ```bash
+    # Esempio con ffmpeg per convertire WAV stereo in WAV mono
+    ffmpeg -i stereo_input.wav -ac 1 mono_output.wav
+    ```
+    *   `-ac 1`: Imposta il numero di canali audio a 1.
+-   **Ricampiona l'Audio:** Assicurati che tutti i file audio abbiano **esattamente lo stesso sampling rate**. Scegli il tuo rate target in base agli obiettivi del progetto e alla compatibilità del framework (ad esempio 16000 Hz, 22050 Hz, 48000 Hz). 22050 Hz è comune per molti modelli.
+    ```bash
+    # Esempio con ffmpeg per ricampionare a 22050 Hz
+    ffmpeg -i input.wav -ar 22050 resampled_output.wav
+    ```
+    *   `-ar 22050`: Imposta il sampling rate audio (campioni al secondo).
+
+### 1.2 Pulizia Audio Avanzata (Rimozione di Rumore/Musica) - *Opzionale ma Consigliata*
+
+-   **Obiettivo:** Rimuovere suoni di sottofondo indesiderati come rumore (ronzio, fruscio, ventole), musica, riverbero o altre voci interferenti dal tuo audio sorgente, isolando il più possibile la voce dello speaker target. Questo passaggio è cruciale se il tuo audio sorgente non è di qualità da studio.
+-   **Perché?** I modelli TTS apprendono dall'audio che ricevono. Se l'audio contiene rumore di fondo o musica, la voce TTS risultante probabilmente erediterà queste caratteristiche, suonando rumorosa o "ovattata". Un audio più pulito porta a una voce TTS più pulita.
+
+-   **Strumenti e Tecniche:**
+    *   **Strumenti di Separazione delle Sorgenti con IA (Consigliati per Musica/Voce):** Questi strumenti usano modelli IA per separare l'audio in diversi stem (voce, musica, batteria, basso, altro).
+        *   **[Ultimate Vocal Remover (UVR)](https://ultimatevocalremover.com/)**: Un'applicazione GUI popolare, gratuita e open-source che fornisce accesso a vari modelli di separazione IA allo stato dell'arte. È eccellente per rimuovere la musica di sottofondo o isolare i dialoghi.
+            *   **Modelli (come quelli citati):** UVR ti consente di usare diversi modelli IA. `MDX-Inst-HQ3` è uno di questi modelli, spesso valido nel separare la voce dagli strumenti (da cui "Inst"). Altri modelli MDX, i modelli Demucs (come `htdemucs`) e potenzialmente modelli come Mel-Roformer (se integrato o disponibile standalone) sono progettati per compiti simili, ciascuno con punti di forza e debolezza leggermente diversi. La sperimentazione è fondamentale. Scegli modelli focalizzati sull'**isolamento vocale**.
+        *   **Altri Strumenti:** Servizi online (ad esempio Lalal.ai) o altri software standalone potrebbero usare modelli sottostanti simili (spesso varianti di Demucs o Spleeter).
+    *   **Strumenti Tradizionali di Riduzione del Rumore:** Spesso presenti nelle Digital Audio Workstation (DAW) o negli editor audio.
+        *   **[Audacity](https://www.audacityteam.org/):** Contiene effetti di riduzione del rumore integrati (richiede di campionare un profilo di rumore). Può essere efficace per il rumore di fondo costante (come fruscio o ronzio).
+        *   **Plugin Commerciali (ad esempio Izotope RX, Waves Clarity):** Offrono strumenti più sofisticati basati su IA per rumore, riverbero e isolamento vocale, ma a pagamento.
+    *   **Editing Spettrale:** Rimozione manuale di suoni indesiderati in un editor spettrale (come Adobe Audition, Izotope RX, Acon Digital Acoustica). Potente ma molto dispendioso in termini di tempo.
+
+-   **Considerazioni sul Flusso di Lavoro:**
+    *   **Quando Applicarla:** Generalmente è consigliato applicare la pulizia ai tuoi **file audio più lunghi *prima* del chunking (Passo 1.3 qui sotto)**. Questo consente ai modelli IA di lavorare con più contesto e può essere più efficiente rispetto all'elaborazione di migliaia di piccoli chunk. Tuttavia, se la pulizia introduce troppi artefatti sui file lunghi, potresti provare a pulire i singoli chunk problematici in seguito.
+    *   **Processo:**
+        1.  Carica il tuo file WAV standardizzato (dal Passo 1.1) nello strumento scelto (ad esempio UVR).
+        2.  Seleziona un modello di isolamento vocale appropriato (ad esempio un modello vocale MDX o Demucs).
+        3.  Elabora l'audio per generare una traccia "solo voce".
+        4.  **Ascolta Attentamente:** Valuta criticamente la traccia vocale separata. Controlla la presenza di:
+            *   **Artefatti:** La separazione IA può talvolta introdurre suoni "acquosi", glitch o parti della voce erroneamente rimosse.
+            *   **Rumore/Musica Residui:** Quanto efficacemente è stato rimosso il suono indesiderato?
+        5.  **Itera:** Potresti dover provare modelli diversi, regolare le impostazioni all'interno dello strumento o persino applicare un secondo passaggio di riduzione del rumore (ad esempio usando la riduzione del rumore di Audacity sulla voce separata dall'IA) per ottenere i migliori risultati.
+    *   **Salva l'Output:** Salva la traccia vocale pulita come nuovo file WAV (ad esempio `original_file_cleaned.wav`). Usa questi file puliti come input per il passo *successivo* (Chunking).
+
+-   **Avvertenze:**
+    *   **Sono Possibili Artefatti:** Una pulizia aggressiva può degradare la naturalezza della voce target. Punta a un equilibrio tra la rimozione del rumore e la conservazione della qualità vocale.
+    *   **Costo Computazionale:** I modelli di separazione IA possono essere computazionalmente intensivi e possono richiedere tempo significativo, specialmente su file audio lunghi e senza una GPU potente.
+
+
+### 1.3. Chunking Audio (Suddivisione in Segmenti)
+
+-   **Obiettivo:** Suddividere i file audio lunghi (come i capitoli di un audiolibro o gli episodi di un podcast) in segmenti più corti e gestibili. La lunghezza ideale di un segmento è tipicamente compresa tra **2 e 15 secondi**.
+-   **Perché Suddividere in Chunk?**
+    *   Allinea la durata dell'audio con le lunghezze tipiche delle frasi.
+    *   Rende fattibile la trascrizione (trascrivere file di ore è difficile).
+    *   Aiuta a gestire la memoria durante l'addestramento.
+    *   Consente di filtrare i segmenti non adatti (ad esempio puro silenzio, rumore, musica).
+-   **Metodo:** Usa strumenti che rilevano il silenzio per suddividere l'audio. `pydub` è una popolare libreria Python per questo.
+
+    ```python
+    # Esempio con pydub per la suddivisione basata sul silenzio
+    from pydub import AudioSegment
+    from pydub.silence import split_on_silence
+    import os
+
+    input_file = "resampled_mono_audio.wav" # Usa l'output del passo 1.1
+    output_dir = "audio_chunks"             # Crea questa directory
+    os.makedirs(output_dir, exist_ok=True)
+
+    print(f"Loading audio file: {input_file}")
+    sound = AudioSegment.from_wav(input_file)
+    print("Audio loaded. Splitting based on silence...")
+
+    chunks = split_on_silence(
+        sound,
+        min_silence_len=500,    # Durata minima del silenzio in millisecondi per attivare una suddivisione. Regola secondo necessità.
+        silence_thresh=-40,     # Soglia di silenzio in dBFS (decibel relativi al fondo scala). Valori più bassi (es. -50) rilevano silenzi più tenui. Regola in base al rumore di fondo del tuo audio.
+        keep_silence=200        # Opzionale: Quantità di silenzio (in ms) da lasciare all'inizio/fine di ogni chunk. Aiuta a evitare tagli bruschi.
+    )
+
+    print(f"Found {len(chunks)} potential chunks before duration filtering.")
+
+    # --- Filtraggio ed Esportazione ---
+    min_duration_sec = 2.0  # Lunghezza minima del chunk in secondi
+    max_duration_sec = 15.0 # Lunghezza massima del chunk in secondi
+    target_sr = 22050       # Assicura che i chunk mantengano il sampling rate corretto (pydub di solito lo gestisce)
+
+    exported_count = 0
+    for i, chunk in enumerate(chunks):
+        duration_sec = len(chunk) / 1000.0
+        if min_duration_sec <= duration_sec <= max_duration_sec:
+            # Assicura che il chunk usi il sampling rate target se necessario (pydub cerca di preservarlo)
+            # chunk = chunk.set_frame_rate(target_sr) # Di solito non necessario se la sorgente era campionata correttamente
+            
+            chunk_filename = f"segment_{exported_count:05d}.wav" # Usa il padding per facilitare l'ordinamento
+            chunk_path = os.path.join(output_dir, chunk_filename)
+            
+            print(f"Exporting chunk {i} ({duration_sec:.2f}s) to {chunk_path}")
+            chunk.export(chunk_path, format="wav")
+            exported_count += 1
+        else:
+             print(f"Skipping chunk {i} due to duration: {duration_sec:.2f}s")
+
+
+    print(f"\nExported {exported_count} chunks meeting duration criteria ({min_duration_sec}-{max_duration_sec}s) to '{output_dir}'.")
+    ```
+-   **Revisione:** Ascolta un campione dei chunk generati. Le suddivisioni sono logiche? Il parlato viene tagliato? Regola `min_silence_len` e `silence_thresh` e riesegui se necessario. La suddivisione manuale o il perfezionamento delle suddivisioni in un editor audio (come Audacity) potrebbe essere necessario per audio complessi.
+
+### 1.4. Normalizzazione del Volume
+
+-   **Obiettivo:** Assicurare che tutti i chunk audio abbiano un livello di volume coerente. Questo evita che i segmenti silenziosi o forti influenzino in modo sproporzionato l'addestramento.
+-   **Metodi:**
+    *   **Peak Normalization:** Regola l'audio in modo che il punto più forte raggiunga un livello specifico (ad esempio -3.0 dBFS). Semplice, ma non garantisce una loudness *percepita* coerente.
+    *   **Loudness Normalization (LUFS):** Regola l'audio per raggiungere un livello target di loudness percepita (ad esempio -23 LUFS è comune per la trasmissione). Generalmente preferita poiché riflette meglio l'udito umano. Richiede librerie come `pyloudnorm`.
+-   **Applica in Modo Coerente:** Applica il metodo di normalizzazione scelto a *tutti* i chunk creati nel passaggio precedente. Salva i file normalizzati in una **nuova directory** (ad esempio `normalized_chunks`) per mantenere intatti gli originali.
+
+    ```python
+    # Esempio con pydub per la PEAK normalization
+    from pydub import AudioSegment
+    import os
+    import glob
+
+    input_chunk_dir = "audio_chunks"
+    output_norm_dir = "normalized_chunks"
+    os.makedirs(output_norm_dir, exist_ok=True)
+    
+    target_dBFS = -3.0 # Ampiezza di picco target
+
+    def match_target_amplitude(sound, target_dBFS):
+        change_in_dBFS = target_dBFS - sound.dBFS
+        return sound.apply_gain(change_in_dBFS)
+
+    print(f"Normalizing chunks from '{input_chunk_dir}' to '{output_norm_dir}' with target peak {target_dBFS} dBFS.")
+    
+    wav_files = glob.glob(os.path.join(input_chunk_dir, "*.wav"))
+    
+    for i, wav_file in enumerate(wav_files):
+        filename = os.path.basename(wav_file)
+        output_path = os.path.join(output_norm_dir, filename)
+        
+        try:
+            sound = AudioSegment.from_wav(wav_file)
+            # Applica il gain solo se il suono non è silenzioso (dBFS non è -inf)
+            if sound.dBFS > -float('inf'):
+              normalized_sound = match_target_amplitude(sound, target_dBFS)
+              normalized_sound.export(output_path, format="wav")
+            else:
+              print(f"Skipping silent file: {filename}")
+              # Opzionalmente copia i file silenziosi o gestiscili secondo necessità
+              # shutil.copy(wav_file, output_path) 
+            
+            if (i + 1) % 50 == 0: # Stampa l'avanzamento
+                 print(f"Processed {i+1}/{len(wav_files)} files...")
+                 
+        except Exception as e:
+            print(f"Error processing {filename}: {e}")
+
+    print(f"\nNormalization complete. Normalized files saved in '{output_norm_dir}'.")
+    ```
+    *   **Nota:** Per la normalizzazione LUFS, useresti una libreria come `pyloudnorm`, iterando sui file in modo simile.
+
+### 1.5. Trascrizione: Creazione delle Coppie Testuali
+
+-   **Obiettivo:** Ottenere una trascrizione testuale accurata per *ogni singolo chunk audio normalizzato*. Il testo deve rappresentare *esattamente* ciò che viene pronunciato nell'audio.
+-   **Metodi:**
+    *   **Automatic Speech Recognition (ASR):** Ideale per dataset di grandi dimensioni. Usa modelli ASR di alta qualità.
+    *   **[OpenAI Whisper](https://github.com/openai/whisper):** Eccellente opzione multilingue e open-source. Si esegue localmente (GPU consigliata) o tramite API. *Nota: Sebbene sia potente per l'accuratezza delle parole, la punteggiatura e la maiuscolazione di Whisper potrebbero richiedere un'attenta revisione e correzione durante la fase di pulizia.* Vari modelli Whisper su cui la community ha effettuato il fine-tuning (spesso disponibili su Hugging Face) potrebbero offrire miglioramenti.
+    *   **[Google Gemini Models](https://ai.google.dev/) (ad esempio tramite API o AI Studio):** Modelli come Gemini Pro o Flash possono eseguire la trascrizione audio. Spesso richiedono che l'audio sia in formati specifici e possono dare i migliori risultati su segmenti più corti (allineandosi bene con il passo di pre-chunking). Verifica le offerte API attuali e i potenziali piani gratuiti.
+    *   **Servizi Cloud:** Google Cloud Speech-to-Text, AWS Transcribe, Azure Speech Service offrono API robuste, spesso con prezzi pay-as-you-go e potenziali piani gratuiti iniziali.
+    *   **Altri Modelli:** Esplora gli [Hugging Face Models](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition) per altri modelli ASR open-source o su cui è stato effettuato il fine-tuning specifici per la tua lingua.
+    *   **Trascrizione Manuale:** La più accurata ma molto dispendiosa in termini di tempo. Adatta per dataset piccoli e di alto valore o per *correggere gli output ASR*.
+    *   **Trascrizioni Esistenti:** Se il tuo audio sorgente è accompagnato da trascrizioni allineate (ad esempio alcuni audiolibri, archivi di trasmissioni), potresti aver bisogno di script per analizzarle e allinearle con i tuoi chunk.
+-   **Formato di Output:** Crea un file `.txt` per ogni corrispondente file `.wav` nella tua directory `normalized_chunks`. I nomi dei file devono corrispondere esattamente (ad esempio, `normalized_chunks/segment_00001.wav` necessita di `transcripts/segment_00001.txt`).
+-   **Pulizia e Normalizzazione del Testo:** **Questo è cruciale!**
+    *   **Rimuovi il Non-Parlato:** Elimina i timestamp (come `[00:01:05]`), le etichette degli speaker ("SPEAKER A:", "John Doe:"), i tag di eventi sonori (`[laughter]`, `[music]`), i commenti di trascrizione.
+    *   **Gestisci le Parole Riempitive:** Decidi se mantenere o rimuovere i comuni riempitivi ("uh", "um", "ah"). Mantenerli potrebbe rendere il TTS più naturale ma può anche introdurre esitazioni indesiderate. Rimuoverli porta a un parlato più pulito e diretto. La coerenza è fondamentale.
+    *   **Punteggiatura:** Assicura una punteggiatura coerente e appropriata. Virgole, punti e punti interrogativi aiutano il modello ad apprendere la prosodia. Evita la punteggiatura eccessiva o non standard.
+    *   **Numeri, Acronimi, Simboli:** Espandili in parole (ad esempio, "101" -> "centouno", "USA" -> "U S A" o "Stati Uniti d'America", "%" -> "percento"). Il modo in cui li espandi dipende da come vuoi che il TTS li pronunci. Crea un dizionario/insieme di regole di normalizzazione se necessario.
+    *   **Maiuscole/Minuscole:** Di solito converti il testo in un formato di maiuscole/minuscole coerente (ad esempio minuscolo) a meno che il tuo framework/tokenizer TTS non gestisca la maiuscolazione in modo appropriato. Controlla la documentazione del framework.
+    *   **Caratteri Speciali:** Rimuovi o sostituisci i caratteri che potrebbero confondere il tokenizer (ad esempio emoji, caratteri di controllo).
+
+    ```
+    # Esempio di struttura:
+    my_tts_dataset/
+    ├── normalized_chunks/
+    │   ├── segment_00001.wav
+    │   ├── segment_00002.wav
+    │   └── ...
+    └── transcripts/
+        ├── segment_00001.txt  # Contiene "Hello world."
+        ├── segment_00002.txt  # Contiene "This is a test sentence."
+        └── ...
+    ```
+
+### 1.6. Strutturazione dei Dati e Creazione del File Manifest
+
+-   **Obiettivo:** Creare file indice (manifest) che indicano allo script di addestramento TTS dove trovare i file audio e le loro corrispondenti trascrizioni.
+-   **Formato del Manifest:** Il formato più comune è un file di testo semplice dove ogni riga rappresenta una coppia audio-testo, separata da un delimitatore (di solito una pipe `|`).
+    ```
+    path/to/audio_chunk.wav|Il testo di trascrizione corrispondente|speaker_id
+    ```
+    *   `path/to/audio_chunk.wav`: Percorso relativo al file audio normalizzato a partire dalla directory in cui verrà eseguito lo script di addestramento.
+    *   `Il testo di trascrizione corrispondente`: Il testo pulito e normalizzato dal file `.txt`.
+    *   `speaker_id`: Un identificatore per lo speaker (ad esempio `speaker0`, `mary_smith`). Per i dataset a singolo speaker, usa lo stesso ID per tutte le righe. Per i dataset multi-speaker, usa ID unici per ogni speaker distinto.
+-   **Suddivisione dei Dati (Train/Validation):** Dividi i tuoi dati in un set di addestramento (usato per aggiornare i pesi del modello) e un set di validazione (usato per monitorare le prestazioni su dati non visti e prevenire l'overfitting). Una suddivisione comune è 90-98% per l'addestramento e 2-10% per la validazione. **In modo cruciale, assicurati che, se possibile, i segmenti provenienti dalla *stessa registrazione lunga originale* non finiscano sia nel set di train che in quello di validation, per evitare il data leakage.** Se suddividi casualmente, mescola prima.
+-   **Script per Generare i Manifest:**
+
+    ```python
+    import os
+    import random
+
+    # --- Configurazione ---
+    dataset_name = "my_tts_dataset"
+    normalized_audio_dir = os.path.join(dataset_name, "normalized_chunks")
+    transcripts_dir = os.path.join(dataset_name, "transcripts")
+    output_dir = dataset_name # Dove verranno salvati i file manifest
+
+    train_manifest_path = os.path.join(output_dir, "train_list.txt")
+    val_manifest_path = os.path.join(output_dir, "val_list.txt")
+
+    speaker_id = "main_speaker" # Usa un ID coerente per i dataset a singolo speaker
+                                # Per multi-speaker, determina l'ID in base al nome del file o alla sorgente
+    val_split_ratio = 0.05    # 5% per il set di validation
+    random_seed = 42          # Per suddivisioni riproducibili
+    # ---------------------
+
+    manifest_entries = []
+    print("Reading audio and transcript files...")
+
+    # Itera sui file audio normalizzati
+    wav_files = sorted([f for f in os.listdir(normalized_audio_dir) if f.endswith(".wav")])
+
+    for wav_filename in wav_files:
+        base_filename = os.path.splitext(wav_filename)[0]
+        txt_filename = base_filename + ".txt"
+        
+        audio_path = os.path.join(normalized_audio_dir, wav_filename)
+        # Usa os.path.relpath se il tuo script di addestramento viene eseguito da una root diversa
+        # relative_audio_path = os.path.relpath(audio_path, start=training_script_dir) 
+        relative_audio_path = audio_path # Si assume che lo script venga eseguito dalla root che contiene 'my_tts_dataset'
+
+        transcript_path = os.path.join(transcripts_dir, txt_filename)
+
+        if os.path.exists(transcript_path):
+            try:
+                with open(transcript_path, "r", encoding="utf-8") as f:
+                    transcript = f.read().strip()
+                
+                # Pulizia di base: rimuovi i caratteri pipe, elimina gli spazi extra
+                transcript = transcript.replace('|', ' ').strip()
+                transcript = ' '.join(transcript.split()) # Normalizza gli spazi bianchi
+
+                if transcript: # Assicura che la trascrizione non sia vuota dopo la pulizia
+                    manifest_entries.append(f"{relative_audio_path}|{transcript}|{speaker_id}")
+                else:
+                    print(f"Warning: Empty transcript for {wav_filename}. Skipping.")
+            except Exception as e:
+                print(f"Error reading or processing transcript {txt_filename}: {e}. Skipping.")
+        else:
+            print(f"Warning: Missing transcript file {txt_filename} for {wav_filename}. Skipping.")
+
+    print(f"Found {len(manifest_entries)} valid audio-transcript pairs.")
+
+    # Mescola e suddividi
+    random.seed(random_seed)
+    random.shuffle(manifest_entries)
+
+    split_idx = int(len(manifest_entries) * (1 - val_split_ratio))
+    train_entries = manifest_entries[:split_idx]
+    val_entries = manifest_entries[split_idx:]
+
+    # Scrivi i file manifest
+    try:
+        with open(train_manifest_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(train_entries))
+        print(f"Successfully wrote {len(train_entries)} entries to {train_manifest_path}")
+
+        with open(val_manifest_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(val_entries))
+        print(f"Successfully wrote {len(val_entries)} entries to {val_manifest_path}")
+    except Exception as e:
+        print(f"Error writing manifest files: {e}")
+
+    ```
+
+---
+
+## 2. Checklist sulla Qualità dei Dati
+
+Prima di passare alla configurazione dell'addestramento, rivedi rigorosamente il tuo dataset preparato usando questa checklist. Correggere i problemi ora fa risparmiare molto tempo in seguito.
+
+| Aspetto                  | Verifica                                                               | Perché è Importante?                                             | Azione in caso di Fallimento                                                                      |
+| :---------------------- | :-------------------------------------------------------------------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| **Completezza Audio**  | Tutti i file `.wav` elencati nei manifest esistono effettivamente?               | L'addestramento andrà in crash se mancano file.                | Rigenera i manifest; controlla i percorsi dei file; assicurati che nessun file sia stato eliminato per errore. |
+| **Corrispondenza Trascrizione**    | Ogni `.wav` ha un `.txt`/trascrizione corrispondente e accurato?    | Le coppie non corrispondenti insegnano al modello associazioni errate. | Verifica i nomi dei file; rivedi l'output ASR; correggi manualmente le trascrizioni.                     |
+| **Lunghezza Audio**        | La maggior parte dei segmenti rientra nell'intervallo desiderato (es. 2-15s)? Pochi valori anomali? | Segmenti molto corti/lunghi possono destabilizzare l'addestramento.       | Riesegui il chunking con parametri regolati; filtra manualmente i valori anomali dai manifest.      |
+| **Qualità Audio**       | Ascolta campioni casuali: Basso rumore di fondo? Niente musica/riverbero/eco? | Garbage In, Garbage Out. Il modello apprende il rumore.         | Migliora l'audio sorgente; applica la riduzione del rumore (con attenzione!); filtra i segmenti scadenti.     |
+| **Coerenza Speaker** | Per il singolo speaker: È sempre la voce target? Nessun altro speaker? | Previene la diluizione o l'instabilità della voce.                    | Rivedi/filtra manualmente i segmenti; controlla i confini del chunking.                         |
+| **Formato e Specifiche** | Tutti WAV? Sampling rate **identico**? Canali mono? PCM 16-bit?      | Le incoerenze causano errori o prestazioni scarse. | Riesegui i passaggi di conversione/ricampionamento (Sezione 1.1). Verifica in batch le specifiche usando strumenti da riga di comando come `ffprobe` o `soxi` (parte del pacchetto [SoX](http://sox.sourceforge.net/)). Esempio: `soxi -r *.wav` per controllare i rate. |
+| **Livelli di Volume**       | Ascolta campioni casuali: I volumi sono relativamente coerenti?          | Variazioni di volume drastiche possono ostacolare l'apprendimento.               | Riesegui la normalizzazione (Sezione 1.3); controlla i parametri di normalizzazione.                 |
+| **Pulizia della Trascrizione** | Nessun timestamp, etichette speaker? Riempitivi gestiti in modo coerente? Punteggiatura standard? Numeri/simboli espansi? | Assicura che il testo si mappi in modo pulito ai suoni del parlato/prosodia.      | Riesegui gli script di pulizia del testo; esegui revisione e correzione manuali.                   |
+| **Formato del Manifest**     | Struttura `path|text|speaker_id` corretta? Percorsi validi? Nessuna riga extra? | Gli errori del parser impediranno il caricamento dei dati.                 | Controlla il delimitatore (`|`); valida i percorsi relativi alla posizione dello script di addestramento; controlla la codifica (UTF-8 preferibile). |
+| **Suddivisione Train/Val**     | I file di validazione sono davvero non visti durante l'addestramento? Nessuna sovrapposizione?        | Dati sovrapposti danno punteggi di validazione fuorvianti.     | Assicura il mescolamento casuale prima della suddivisione; controlla la logica di suddivisione.                        |
+
+**Suggerimento:** Usa strumenti come `soxi` (da SoX) o `ffprobe` per controllare in batch le proprietà audio (sampling rate, canali, durata). Scrivi piccoli script per verificare l'esistenza dei file e la formattazione di base del manifest.
+
+### 2.1. Script Pratici di Verifica
+
+Ecco alcuni script pratici per aiutarti a verificare la qualità del tuo dataset:
+
+#### Controllare le Proprietà Audio (Sampling Rate, Canali, Durata)
+
+```bash
+#!/bin/bash
+# verify_audio.sh - Controlla le proprietà audio di tutti i file WAV
+# Uso: ./verify_audio.sh /path/to/audio/directory
+
+AUDIO_DIR="$1"
+echo "Checking audio files in $AUDIO_DIR..."
+
+# Controlla se SoX è installato
+if ! command -v soxi &> /dev/null; then
+    echo "SoX not found. Please install it first (e.g., 'apt-get install sox' or 'brew install sox')."
+    exit 1
+fi
+
+# Inizializza contatori e array
+total_files=0
+non_mono=0
+wrong_rate=0
+too_short=0
+too_long=0
+target_rate=22050  # Cambia questo con il tuo sampling rate target
+min_duration=1.0   # Durata minima in secondi
+max_duration=15.0  # Durata massima in secondi
+
+# Elabora tutti i file WAV
+find "$AUDIO_DIR" -name "*.wav" | while read -r file; do
+    total_files=$((total_files + 1))
+    
+    # Ottieni le proprietà audio
+    channels=$(soxi -c "$file")
+    rate=$(soxi -r "$file")
+    duration=$(soxi -d "$file" | awk -F: '{ print ($1 * 3600) + ($2 * 60) + $3 }')
+    
+    # Controlla le proprietà
+    if [ "$channels" -ne 1 ]; then
+        echo "WARNING: Non-mono file: $file (channels: $channels)"
+        non_mono=$((non_mono + 1))
+    fi
+    
+    if [ "$rate" -ne "$target_rate" ]; then
+        echo "WARNING: Wrong sampling rate: $file (rate: $rate Hz, expected: $target_rate Hz)"
+        wrong_rate=$((wrong_rate + 1))
+    fi
+    
+    if (( $(echo "$duration < $min_duration" | bc -l) )); then
+        echo "WARNING: File too short: $file (duration: ${duration}s, minimum: ${min_duration}s)"
+        too_short=$((too_short + 1))
+    fi
+    
+    if (( $(echo "$duration > $max_duration" | bc -l) )); then
+        echo "WARNING: File too long: $file (duration: ${duration}s, maximum: ${max_duration}s)"
+        too_long=$((too_long + 1))
+    fi
+    
+    # Stampa l'avanzamento ogni 100 file
+    if [ $((total_files % 100)) -eq 0 ]; then
+        echo "Processed $total_files files..."
+    fi
+done
+
+# Stampa il riepilogo
+echo "===== SUMMARY ====="
+echo "Total files checked: $total_files"
+echo "Non-mono files: $non_mono"
+echo "Files with wrong sampling rate: $wrong_rate"
+echo "Files too short (<${min_duration}s): $too_short"
+echo "Files too long (>${max_duration}s): $too_long"
+
+if [ $((non_mono + wrong_rate + too_short + too_long)) -eq 0 ]; then
+    echo "All files passed basic checks!"
+else
+    echo "Some issues were found. Please review the warnings above."
+fi
+```
+
+#### Verificare l'Integrità del File Manifest
+
+```python
+#!/usr/bin/env python3
+# verify_manifest.py - Controlla che tutti i file nel manifest esistano e abbiano trascrizioni corrispondenti
+# Uso: python verify_manifest.py path/to/manifest.txt
+
+import os
+import sys
+from pathlib import Path
+
+def verify_manifest(manifest_path):
+    """Verify that all audio files and transcripts in the manifest exist and are valid."""
+    if not os.path.exists(manifest_path):
+        print(f"Error: Manifest file '{manifest_path}' not found.")
+        return False
+    
+    print(f"Verifying manifest: {manifest_path}")
+    base_dir = os.path.dirname(os.path.abspath(manifest_path))
+    
+    # Statistiche
+    total_entries = 0
+    missing_audio = 0
+    empty_transcripts = 0
+    
+    with open(manifest_path, 'r', encoding='utf-8') as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            
+            total_entries += 1
+            
+            # Analizza la riga (assumendo il formato separato da pipe: audio_path|transcript|speaker_id)
+            parts = line.split('|')
+            if len(parts) < 2:
+                print(f"Line {line_num}: Invalid format. Expected at least 'audio_path|transcript'")
+                continue
+            
+            audio_path = parts[0]
+            transcript = parts[1]
+            
+            # Controlla se il percorso audio è relativo e risolvilo
+            if not os.path.isabs(audio_path):
+                audio_path = os.path.join(base_dir, audio_path)
+            
+            # Controlla se il file audio esiste
+            if not os.path.exists(audio_path):
+                print(f"Line {line_num}: Audio file not found: {audio_path}")
+                missing_audio += 1
+            
+            # Controlla se la trascrizione è vuota
+            if not transcript or transcript.isspace():
+                print(f"Line {line_num}: Empty transcript for {audio_path}")
+                empty_transcripts += 1
+    
+    # Stampa il riepilogo
+    print("\n===== SUMMARY =====")
+    print(f"Total entries: {total_entries}")
+    print(f"Missing audio files: {missing_audio}")
+    print(f"Empty transcripts: {empty_transcripts}")
+    
+    if missing_audio == 0 and empty_transcripts == 0:
+        print("All manifest entries are valid!")
+        return True
+    else:
+        print("Issues found in manifest. Please fix them before proceeding.")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python verify_manifest.py path/to/manifest.txt")
+        sys.exit(1)
+    
+    success = verify_manifest(sys.argv[1])
+    sys.exit(0 if success else 1)
+```
+
+#### Visualizzare gli Spettrogrammi Audio per la Valutazione della Qualità
+
+Questo script ti aiuta a ispezionare visivamente la qualità dei tuoi file audio generando spettrogrammi:
+
+```python
+#!/usr/bin/env python3
+# generate_spectrograms.py - Crea spettrogrammi per la valutazione della qualità audio
+# Uso: python generate_spectrograms.py /path/to/audio/directory /path/to/output/directory [num_samples]
+
+import os
+import sys
+import random
+import numpy as np
+import matplotlib.pyplot as plt
+import librosa
+import librosa.display
+from pathlib import Path
+
+def generate_spectrograms(audio_dir, output_dir, num_samples=10):
+    """Generate spectrograms for a random sample of audio files."""
+    # Crea la directory di output se non esiste
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Ottieni tutti i file WAV
+    wav_files = list(Path(audio_dir).glob('**/*.wav'))
+    if not wav_files:
+        print(f"No WAV files found in {audio_dir}")
+        return False
+    
+    # Campiona i file se ce ne sono più di quelli richiesti
+    if len(wav_files) > num_samples:
+        wav_files = random.sample(wav_files, num_samples)
+    
+    print(f"Generating spectrograms for {len(wav_files)} files...")
+    
+    for i, wav_path in enumerate(wav_files):
+        try:
+            # Carica il file audio
+            y, sr = librosa.load(wav_path, sr=None)
+            
+            # Crea la figura con due sottografici
+            plt.figure(figsize=(12, 8))
+            
+            # Traccia la forma d'onda
+            plt.subplot(2, 1, 1)
+            librosa.display.waveshow(y, sr=sr)
+            plt.title(f'Waveform: {wav_path.name}')
+            plt.xlabel('Time (s)')
+            plt.ylabel('Amplitude')
+            
+            # Traccia lo spettrogramma
+            plt.subplot(2, 1, 2)
+            D = librosa.amplitude_to_db(np.abs(librosa.stft(y)), ref=np.max)
+            librosa.display.specshow(D, sr=sr, x_axis='time', y_axis='log')
+            plt.colorbar(format='%+2.0f dB')
+            plt.title('Log-frequency power spectrogram')
+            
+            # Salva la figura
+            output_path = os.path.join(output_dir, f'spectrogram_{i+1}_{wav_path.stem}.png')
+            plt.tight_layout()
+            plt.savefig(output_path)
+            plt.close()
+            
+            print(f"Generated: {output_path}")
+            
+        except Exception as e:
+            print(f"Error processing {wav_path}: {e}")
+    
+    print(f"Spectrograms saved to {output_dir}")
+    return True
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python generate_spectrograms.py /path/to/audio/directory /path/to/output/directory [num_samples]")
+        sys.exit(1)
+    
+    audio_dir = sys.argv[1]
+    output_dir = sys.argv[2]
+    num_samples = int(sys.argv[3]) if len(sys.argv) > 3 else 10
+    
+    success = generate_spectrograms(audio_dir, output_dir, num_samples)
+    sys.exit(0 if success else 1)
+```
+
+Questi script forniscono strumenti pratici per verificare la qualità del tuo dataset prima dell'addestramento, aiutandoti a identificare e correggere i problemi nelle prime fasi del processo.
+
+---
+
+Una volta che il tuo dataset supera questo controllo di qualità, sei pronto a procedere con la configurazione dell'ambiente di addestramento.
+
+**Passo Successivo:** [Configurazione dell'Addestramento](./2_TRAINING_SETUP.md){: .btn .btn-primary} |
+[Torna in Cima](#top){: .btn .btn-primary}

--- a/languages/it/guides/2_TRAINING_SETUP.md
+++ b/languages/it/guides/2_TRAINING_SETUP.md
@@ -1,0 +1,253 @@
+# Guida 2: Configurazione e Setup dell'Ambiente di Addestramento
+
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Precedente: Preparazione dei Dati](./1_DATA_PREPARATION.md){: .btn .btn-primary} | [Passo Successivo: Addestramento del Modello](./3_MODEL_TRAINING.md){: .btn .btn-primary}
+
+Con il tuo dataset preparato, la fase successiva comporta la configurazione dell'ambiente software necessario e l'impostazione dei parametri per la tua specifica esecuzione di addestramento.
+
+---
+
+## 3. Setup dell'Ambiente di Addestramento
+
+Questa sezione copre l'installazione del software necessario e l'organizzazione dei file di progetto.
+
+### 3.1. Scegliere e Clonare un Framework TTS
+
+-   **Seleziona un Framework:** Scegli una codebase TTS adatta ai tuoi obiettivi. Considera fattori come:
+    *   **Architettura:** VITS, StyleTTS2, Tacotron2+Vocoder, ecc. Le architetture più recenti spesso producono una qualità migliore.
+    *   **Supporto al Fine-tuning:** Il framework supporta esplicitamente il fine-tuning da modelli pre-addestrati? Questo è spesso più facile che addestrare da zero.
+    *   **Supporto Linguistico:** Verifica se il modello/tokenizer gestisce bene la tua lingua target.
+    *   **Community e Manutenzione:** Il repository è mantenuto attivamente? Ci sono discussioni della community o canali di supporto?
+    *   **Modelli Pre-addestrati:** Il framework fornisce modelli pre-addestrati adatti come punto di partenza per il fine-tuning?
+
+#### Confronto delle Architetture TTS
+
+Quando selezioni un'architettura TTS, considera queste opzioni popolari e le loro caratteristiche:
+
+| Architettura | Pro | Contro | Ideale Per | Requisiti Hardware |
+|:-------------|:-----|:-----|:---------|:---------------------|
+| **VITS** | • End-to-end (nessun vocoder separato)<br>• Audio di alta qualità<br>• Inferenza veloce<br>• Buono per il fine-tuning | • Complesso da comprendere<br>• Può essere instabile durante l'addestramento<br>• Richiede un'attenta messa a punto degli iperparametri | • Voice cloning a singolo speaker<br>• Progetti che necessitano di output di alta qualità<br>• Quando hai più di 5 ore di dati | • Addestramento: 8GB+ VRAM<br>• Inferenza: 4GB+ VRAM |
+| **StyleTTS2** | • Eccellente controllo di voce e stile<br>• Qualità allo stato dell'arte<br>• Buono per emozione/prosodia | • Più recente, implementazioni potenzialmente meno stabili<br>• Architettura più complessa<br>• Meno risorse della community | • Progetti che richiedono controllo dello stile<br>• Sintesi vocale espressiva<br>• Multi-speaker con style transfer | • Addestramento: 12GB+ VRAM<br>• Inferenza: 6GB+ VRAM |
+| **Tacotron2 + HiFi-GAN** | • Ben consolidato, stabile<br>• Più facile da comprendere<br>• Più tutorial disponibili<br>• Componenti separati per un debug più facile | • Pipeline a due stadi (più lenta)<br>• Generalmente qualità inferiore rispetto ai modelli più recenti<br>• Più soggetto a errori di attention su testi lunghi | • Progetti didattici<br>• Quando la stabilità ha priorità sulla qualità<br>• Ambienti con meno risorse | • Addestramento: 6GB+ VRAM<br>• Inferenza: 2GB+ VRAM |
+| **FastSpeech2** | • Non-autoregressivo (inferenza più veloce)<br>• Più stabile di Tacotron2<br>• Buona documentazione | • Richiede allineamenti fonemici<br>• Preprocessing più complesso<br>• Qualità non alta come VITS/StyleTTS2 | • Applicazioni in tempo reale<br>• Quando la velocità di inferenza è critica<br>• Output più controllato | • Addestramento: 8GB+ VRAM<br>• Inferenza: 2GB+ VRAM |
+| **YourTTS (variante di VITS)** | • Supporto multilingue<br>• Voice cloning zero-shot<br>• Buono per il transfer linguistico | • Setup di addestramento complesso<br>• Richiede un'attenta preparazione dei dati<br>• Potrebbe necessitare di dataset più grandi | • Progetti multilingue<br>• Voice cloning cross-linguale<br>• Quando è necessaria flessibilità linguistica | • Addestramento: 10GB+ VRAM<br>• Inferenza: 4GB+ VRAM |
+| **TTS basato su Diffusion** | • Massimo potenziale di qualità<br>• Prosodia più naturale<br>• Migliore gestione delle parole rare | • Inferenza molto lenta<br>• Addestramento estremamente intensivo in termini di calcolo<br>• Più recente, meno consolidato | • Generazione offline<br>• Quando la qualità conta più della velocità<br>• Progetti di ricerca | • Addestramento: 16GB+ VRAM<br>• Inferenza: 8GB+ VRAM |
+
+**Nota sui Requisiti Hardware:**
+- Questi sono minimi approssimativi; batch size più grandi o configurazioni del modello richiederanno più VRAM
+- I tempi di addestramento variano significativamente: VITS/StyleTTS2 tipicamente necessitano di più epoche di Tacotron2
+- L'inferenza su CPU è possibile per tutti i modelli ma sarà significativamente più lenta
+
+### 1.3. Requisiti Hardware Dettagliati
+
+Scegliere l'hardware giusto è fondamentale per un addestramento riuscito di modelli TTS. Ecco una ripartizione dettagliata dei requisiti per diversi scenari:
+
+#### Requisiti GPU per Tipo di Modello e Dimensione del Dataset
+
+| Tipo di Modello | Dataset Piccolo (<10h) | Dataset Medio (10-50h) | Dataset Grande (>50h) | Modelli GPU Consigliati |
+|:-----------|:---------------------|:------------------------|:---------------------|:-----------------------|
+| **Tacotron2 + HiFi-GAN** | 8GB VRAM | 12GB VRAM | 16GB+ VRAM | RTX 3060, RTX 2080, T4 |
+| **FastSpeech2** | 8GB VRAM | 12GB VRAM | 16GB+ VRAM | RTX 3060, RTX 2080, T4 |
+| **VITS** | 12GB VRAM | 16GB VRAM | 24GB+ VRAM | RTX 3080, RTX 3090, A5000 |
+| **StyleTTS2** | 16GB VRAM | 24GB VRAM | 32GB+ VRAM | RTX 3090, RTX 4090, A100 |
+| **XTTS-v2** | 24GB VRAM | 32GB VRAM | 40GB+ VRAM | RTX 4090, A100, A6000 |
+| **TTS basato su Diffusion** | 16GB VRAM | 24GB VRAM | 32GB+ VRAM | RTX 3090, RTX 4090, A100 |
+
+#### CPU e Memoria di Sistema
+
+| Scala di Addestramento | Requisiti CPU | RAM di Sistema | Storage |
+|:---------------|:-----------------|:-----------|:--------|
+| **Hobby/Personale** | 4+ core, 2.5GHz+ | 16GB | 50GB SSD |
+| **Ricerca** | 8+ core, 3.0GHz+ | 32GB | 100GB+ SSD |
+| **Produzione** | 16+ core, 3.5GHz+ | 64GB+ | 500GB+ NVMe SSD |
+
+#### Opzioni di GPU Cloud e Costi Approssimativi
+
+| Provider Cloud | Opzione GPU | VRAM | Costo Approx./Ora | Ideale Per |
+|:---------------|:-----------|:-----|:------------------|:---------|
+| **Google Colab** | T4/P100 (Free)<br>V100/A100 (Pro) | 16GB<br>16-40GB | Free<br>$10-$15 | Sperimentazione, dataset piccoli |
+| **Kaggle** | P100/T4 | 16GB | Free (ore limitate) | Dataset piccoli-medi |
+| **AWS** | g4dn.xlarge (T4)<br>p3.2xlarge (V100)<br>p4d.24xlarge (A100) | 16GB<br>16GB<br>40GB | $0.50-$0.75<br>$3.00-$3.50<br>$20.00-$32.00 | Qualsiasi scala, produzione |
+| **GCP** | n1-standard-8 + T4<br>a2-highgpu-1g (A100) | 16GB<br>40GB | $0.35-$0.50<br>$3.80-$4.50 | Qualsiasi scala, produzione |
+| **Azure** | NC6s_v3 (V100)<br>NC24ads_A100_v4 | 16GB<br>80GB | $3.00-$3.50<br>$16.00-$24.00 | Qualsiasi scala, produzione |
+| **Lambda Labs** | 1x RTX 3090<br>1x A100 | 24GB<br>40GB | $1.10<br>$1.99 | Ricerca, dataset medi |
+| **Vast.ai** | Varie GPU consumer | 8-24GB | $0.20-$1.00 | Addestramento con budget limitato |
+
+#### Stime dei Tempi di Addestramento
+
+| Modello | Dimensione Dataset | GPU | Tempo di Addestramento Approssimativo | Epoche fino alla Convergenza |
+|:------|:-------------|:----|:--------------------------|:----------------------|
+| **Tacotron2 + HiFi-GAN** | 10 ore | RTX 3080 | 2-3 giorni | 50-100K step |
+| **FastSpeech2** | 10 ore | RTX 3080 | 2-3 giorni | 150-200K step |
+| **VITS** | 10 ore | RTX 3090 | 3-5 giorni | 300-500K step |
+| **StyleTTS2** | 10 ore | RTX 3090 | 4-7 giorni | 500-800K step |
+| **XTTS-v2** | 10 ore | RTX 4090 | 5-10 giorni | 1M+ step |
+
+#### Suggerimenti di Ottimizzazione per Ridurre i Requisiti Hardware
+
+1. **Gradient Accumulation**: Simula batch size più grandi accumulando i gradienti su più passaggi forward/backward
+2. **Mixed Precision Training**: Usa FP16 invece di FP32 per ridurre l'uso di VRAM fino al 50%
+3. **Gradient Checkpointing**: Scambia il calcolo con la memoria ricalcolando le attivazioni durante il backward pass
+4. **Model Parallelism**: Suddividi i modelli grandi su più GPU
+5. **Progressive Training**: Inizia con modelli/configurazioni più piccoli e aumenta gradualmente la complessità
+
+Questi requisiti dovrebbero aiutarti a pianificare le tue necessità hardware in base agli obiettivi specifici del tuo progetto e ai vincoli di budget.
+-   **Clona il Repository:** Una volta scelto, clona il repository del codice del framework usando Git.
+    ```bash
+    git clone <URL_OF_YOUR_CHOSEN_TTS_REPO>
+    cd <TTS_REPO_DIRECTORY> # Naviga nella directory clonata
+    ```
+    *   Esempio: `git clone https://github.com/some-user/some-tts-framework.git`
+
+### 3.2. Configurare l'Ambiente Python e Installare le Dipendenze
+
+-   **Ambiente Virtuale (Consigliato):** Crea e attiva un ambiente virtuale Python dedicato per isolare le dipendenze ed evitare conflitti con altri progetti o con i pacchetti Python di sistema.
+    *   **Usando `venv` (integrato):**
+        ```bash
+        python -m venv venv_tts  # Crea un ambiente chiamato 'venv_tts'
+        # Attivalo:
+        # Windows: .\venv_tts\Scripts\activate
+        # Linux/macOS: source venv_tts/bin/activate
+        ```
+    *   **Usando `conda`:**
+        ```bash
+        conda create --name tts_env python=3.9 # O la versione Python desiderata
+        conda activate tts_env
+        ```
+-   **Installa PyTorch con CUDA:** Questo è fondamentale per l'accelerazione GPU. Visita la [Guida Ufficiale di Installazione di PyTorch](https://pytorch.org/get-started/locally/) e seleziona le opzioni corrispondenti al tuo OS, package manager (`pip` o `conda`), piattaforma di calcolo (versione CUDA) e versione di PyTorch desiderata. **Assicurati che i driver NVIDIA installati siano compatibili con la versione CUDA scelta.**
+    ```bash
+    # Comando di esempio con pip per CUDA 11.8 (controlla il sito di PyTorch per i comandi attuali!)
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+    # Verifica l'installazione:
+    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); print(torch.version.cuda)"
+    # Dovrebbe restituire la versione di PyTorch, True e la tua versione CUDA se ha successo.
+    ```
+-   **Installa i Requisiti del Framework:** La maggior parte dei framework elenca le proprie dipendenze in un file `requirements.txt`. Installale usando `pip` (o `uv`, che spesso è più veloce).
+    ```bash
+    # Naviga prima nella directory del framework se non sei già lì
+    # Usando pip:
+    pip install -r requirements.txt
+
+    # Usando uv (se installato: pip install uv):
+    uv pip install -r requirements.txt
+    ```
+    *   **Risoluzione dei Problemi:** Presta attenzione a eventuali errori di installazione. Potrebbero indicare librerie di sistema mancanti (come `libsndfile`), versioni di pacchetti incompatibili o problemi con la tua configurazione CUDA/PyTorch. Controlla la documentazione del framework per i prerequisiti specifici.
+
+### 3.3. Organizzare la Cartella del Progetto
+
+-   Una struttura di cartelle ben organizzata semplifica la gestione del tuo progetto. Colloca il tuo dataset preparato (o crea un link simbolico ad esso) all'interno o accanto al codice del framework. Una struttura comune si presenta così:
+
+    ```bash
+    <YOUR_PROJECT_ROOT>/
+    ├── <TTS_REPO_DIRECTORY>/         # Il codice del framework clonato
+    │   ├── train.py                 # Script di addestramento principale (il nome può variare)
+    │   ├── inference.py             # Script di inferenza (il nome può variare)
+    │   ├── configs/                 # Directory per i file di configurazione
+    │   │   └── base_config.yaml     # Esempio di config del framework
+    │   ├── requirements.txt
+    │   └── ... (altri file del framework)
+    │
+    ├── my_tts_dataset/              # Il tuo dataset preparato dalla Guida 1
+    │   ├── normalized_chunks/       # File audio finali
+    │   │   ├── segment_00001.wav
+    │   │   └── ...
+    │   ├── transcripts/             # Opzionale: file di testo se non direttamente nel manifest
+    │   ├── train_list.txt           # Manifest di addestramento
+    │   └── val_list.txt             # Manifest di validazione
+    │
+    ├── checkpoints/                 # Crea questa directory: Dove verranno salvati i modelli
+    │   └── my_custom_model/         # Sottodirectory per una specifica esecuzione di addestramento
+    │
+    └── my_configs/                  # Opzionale: Colloca qui le tue config personalizzate
+        └── my_training_run_config.yaml
+    ```
+-   **Percorsi:** Assicurati che i percorsi specificati successivamente nel tuo file di configurazione (per dataset, output) siano corretti rispetto alla posizione da cui *eseguirai* lo script `train.py` (di solito da dentro la `<TTS_REPO_DIRECTORY>`).
+
+---
+
+## 4. Configurare l'Esecuzione dell'Addestramento
+
+Prima di avviare l'addestramento, devi creare un file di configurazione che indichi al framework *come* addestrare il modello, usando i *tuoi* dati specifici.
+
+### 4.1. Trovare e Copiare una Configurazione Base
+
+-   **Individua gli Esempi:** Esplora la directory `configs/` all'interno del framework TTS. Cerca file di configurazione (`.yaml`, `.json` o simili) che fungano da template.
+-   **Scegli in Modo Appropriato:** Seleziona un file di config che corrisponda al tuo obiettivo:
+    *   **Fine-tuning:** Cerca nomi come `config_ft.yaml`, `finetune_*.yaml`. Questi spesso presuppongono che fornirai un modello pre-addestrato.
+    *   **Addestramento da Zero:** Cerca nomi come `config_base.yaml`, `train_*.yaml`.
+    *   **Dimensione del Dataset:** Alcuni framework potrebbero offrire config ottimizzate per dataset piccoli (`_sm`) o grandi (`_lg`).
+-   **Copia e Rinomina:** Copia il file template scelto in una nuova posizione (ad esempio la tua directory `my_configs/` o all'interno della directory `configs/` del framework) e dagli un nome descrittivo per la tua esecuzione specifica (ad esempio `my_yoruba_voice_ft_config.yaml`).
+    ```bash
+    # Esempio: Copiare una config di fine-tuning
+    cp <TTS_REPO_DIRECTORY>/configs/base_finetune_config.yaml my_configs/my_yoruba_voice_ft_config.yaml
+    ```
+
+### 4.2. Modificare il Tuo File di Configurazione Personalizzato
+
+-   Apri il tuo file di configurazione appena copiato (`my_yoruba_voice_ft_config.yaml`) in un editor di testo.
+-   **Modifica i Parametri Chiave:** Rivedi e modifica con attenzione i parametri. I nomi dei parametri **varieranno significativamente** tra i framework, ma le categorie comuni includono:
+
+    ```yaml
+    # --- Dataset e Caricamento dei Dati ---
+    # Percorsi relativi alla posizione da cui esegui train.py
+    train_filelist_path: "../my_tts_dataset/train_list.txt" # Percorso al tuo manifest di addestramento
+    val_filelist_path: "../my_tts_dataset/val_list.txt"   # Percorso al tuo manifest di validazione
+    # Alcuni framework potrebbero necessitare di 'data_path' o 'audio_root' che puntino alla directory audio in alternativa/aggiunta.
+
+    # --- Output e Logging ---
+    output_directory: "../checkpoints/my_yoruba_voice_run1" # MOLTO IMPORTANTE: Dove vengono salvati modelli, log e sample. Crea questa dir base se necessario.
+    log_interval: 100                  # Ogni quanto (in step/batch) stampare i log
+    validation_interval: 1000          # Ogni quanto (in step/batch) eseguire la validazione
+    save_checkpoint_interval: 5000     # Ogni quanto (in step/batch) salvare i checkpoint del modello
+
+    # --- Iperparametri Principali di Addestramento ---
+    epochs: 1000                       # Numero totale di passaggi sui dati di addestramento. Regola in base alla dimensione del dataset e alla convergenza.
+    batch_size: 16                     # Numero di sample elaborati in parallelo per GPU. RIDUCI se ottieni errori CUDA OOM. AUMENTA per un addestramento più veloce se la VRAM lo consente.
+    learning_rate: 1e-4                # Learning rate iniziale. Potrebbe richiedere una messa a punto (es. più basso per il fine-tuning: 5e-5 o 1e-5).
+    # lr_scheduler: "cosine_decay"     # Schedule del learning rate (es. step decay, exponential decay) - dipende dal framework
+    # weight_decay: 0.01               # Parametro di regolarizzazione
+
+    # --- Parametri Audio ---
+    sampling_rate: 22050               # CRITICO: DEVE corrispondere al sampling rate del tuo dataset preparato (dalla Guida 1).
+    # Altri parametri audio (spesso dipendono dall'architettura del modello):
+    # filter_length: 1024              # Dimensione FFT per la STFT
+    # hop_length: 256                  # Hop size per la STFT
+    # win_length: 1024                 # Window size per la STFT
+    # n_mel_channels: 80               # Numero di bande Mel
+    # mel_fmin: 0.0                    # Frequenza Mel minima
+    # mel_fmax: 8000.0                 # Frequenza Mel massima (spesso sampling_rate / 2)
+
+    # --- Architettura del Modello ---
+    # model_type: "VITS"               # Tipo di architettura del modello
+    # hidden_channels: 192             # Dimensione dei layer interni
+    # num_speakers: 1                  # Imposta a >1 per i dataset multi-speaker (deve corrispondere alla preparazione dati)
+
+    # --- Specifiche del Fine-tuning (Se Applicabile) ---
+    # Imposta 'True' o fornisci il percorso durante il fine-tuning
+    fine_tuning: True
+    pretrained_model_path: "/path/to/downloaded/base_model.pth" # Percorso al checkpoint pre-addestrato da cui partire.
+    # Opzionale: Specifica i layer da ignorare/reinizializzare se necessario
+    # ignore_layers: ["speaker_embedding.weight", "decoder.output_layer.weight"]
+    ```
+-   **Leggi la Documentazione del Framework:** Consulta la documentazione specifica del framework TTS scelto per capire cosa fa ciascun parametro nel suo file di configurazione.
+
+### 4.3. Considerazioni su Hardware e Dataset
+
+-   **VRAM GPU:** Il `batch_size` è la manopola principale per controllare l'uso della memoria GPU. Inizia con un valore consigliato (ad esempio 16 o 32) e riducilo se incontri errori "CUDA out of memory" durante l'avvio dell'addestramento. Batch size più grandi generalmente portano a una convergenza più veloce ma richiedono più VRAM.
+-   **Dimensione del Dataset vs. Epoche:**
+    *   **Dataset Piccoli (< 20h):** Potrebbero richiedere meno epoche (ad esempio 300-1500) ma necessitano di un attento monitoraggio tramite validation loss/sample per evitare l'overfitting (dove il modello memorizza i dati di addestramento ma ha prestazioni scarse su nuovo testo). Considera learning rate più bassi.
+    *   **Dataset Grandi (> 50h):** Possono beneficiare di più epoche (1000+) per apprendere completamente i pattern nei dati.
+-   **CPU:** Mentre la GPU fa il lavoro pesante, è necessaria una CPU multi-core decente per il caricamento dei dati e il pre-processing, che altrimenti possono diventare un collo di bottiglia.
+-   **Storage:** Assicurati di avere abbastanza spazio su disco per il dataset, l'ambiente Python, il codice del framework e specialmente i checkpoint salvati, che possono diventare grandi (da centinaia di MB a GB per checkpoint).
+
+### 4.4. Strumenti di Monitoraggio (TensorBoard)
+
+-   La maggior parte dei framework TTS moderni si integra con [TensorBoard](https://www.tensorflow.org/tensorboard) per visualizzare i progressi dell'addestramento.
+-   Il file di configurazione spesso ha impostazioni relative al logging (ad esempio `use_tensorboard: True`, `log_directory`).
+-   Durante l'addestramento, puoi tipicamente avviare TensorBoard eseguendo `tensorboard --logdir <YOUR_OUTPUT_DIRECTORY>` (ad esempio `tensorboard --logdir ../checkpoints/my_yoruba_voice_run1`) in un terminale separato. Questo ti consente di monitorare le curve di loss, i learning rate e potenzialmente di ascoltare i sample di validazione sintetizzati nel tuo browser web.
+
+---
+
+Con il tuo ambiente configurato e il file di configurazione adattato ai tuoi dati e obiettivi, sei ora pronto ad avviare il vero e proprio processo di addestramento del modello.
+
+**Passo Successivo:** [Addestramento del Modello](./3_MODEL_TRAINING.md){: .btn .btn-primary} | 
+[Torna in Cima](#top){: .btn .btn-primary}

--- a/languages/it/guides/3_MODEL_TRAINING.md
+++ b/languages/it/guides/3_MODEL_TRAINING.md
@@ -1,0 +1,281 @@
+# Guida 3: Addestramento e Fine-tuning del Modello
+
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Precedente: Configurazione dell'Addestramento](./2_TRAINING_SETUP.md){: .btn .btn-primary} | [Passo Successivo: Inferenza](./4_INFERENCE.md){: .btn .btn-primary}
+
+Hai preparato i tuoi dati e configurato il tuo ambiente di addestramento. Ora è il momento di addestrare effettivamente (o effettuare il fine-tuning) del tuo modello Text-to-Speech. Questa fase comporta l'esecuzione dello script di addestramento, il monitoraggio dei suoi progressi e la comprensione di come gestire il processo.
+
+---
+
+## 5. Esecuzione dell'Addestramento
+
+Questa sezione descrive in dettaglio come avviare, monitorare e gestire il processo di addestramento.
+
+### 5.1. Avviare lo Script di Addestramento
+
+-   **Naviga nella Directory Corretta:** Apri il tuo terminale o prompt dei comandi e naviga nella directory principale del repository del framework TTS clonato (la directory contenente lo script `train.py` o il suo equivalente).
+-   **Attiva l'Ambiente Virtuale:** Assicurati che il tuo ambiente virtuale Python dedicato (ad esempio `venv_tts`, `tts_env`) sia attivato.
+    ```bash
+    # Esempio di attivazione (adatta percorso/nome secondo necessità)
+    # Windows: ..\venv_tts\Scripts\activate
+    # Linux/macOS: source ../venv_tts/bin/activate
+    # Conda: conda activate tts_env
+    ```
+-   **Esegui il Comando di Addestramento:** Esegui lo script di addestramento del framework, indirizzandolo al tuo file di configurazione personalizzato creato nella Guida 2. La struttura esatta del comando varia tra i framework. I pattern comuni includono:
+    ```bash
+    # Pattern Comune 1: Usando l'argomento --config
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml
+
+    # Pattern Comune 2: Usando -c per la config e -m per il nome della directory del modello/output
+    # (Verifica se la tua output_directory nella config viene sovrascritta da -m)
+    python train.py -c ../my_configs/my_yoruba_voice_ft_config.yaml -m my_yoruba_voice_run1
+
+    # Pattern Comune 3: Specificando direttamente la directory dei checkpoint
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --checkpoint_path ../checkpoints/my_yoruba_voice_run1
+    ```
+    *   **Addestramento Multi-GPU:** Se hai più GPU e il framework supporta l'addestramento distribuito (controlla la sua documentazione), potresti usare comandi che coinvolgono `torchrun` o `python -m torch.distributed.launch`. Esempio:
+        ```bash
+        # Esempio con torchrun (regola nproc_per_node in base al tuo numero di GPU)
+        torchrun --nproc_per_node=2 train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml
+        ```
+
+### 5.2. Monitorare i Progressi dell'Addestramento
+
+-   **Output della Console:** Il terminale da cui hai avviato l'addestramento mostrerà informazioni sui progressi. Cerca:
+    *   **Inizializzazione:** Messaggi che indicano che il modello viene costruito, i data loader vengono preparati e potenzialmente un modello pre-addestrato viene caricato (per il fine-tuning).
+    *   **Epoche/Step:** Progressi attuali dell'addestramento (ad esempio `Epoch: [1/1000]`, `Step: [500/100000]`).
+    *   **Valori di Loss:** Metriche cruciali che indicano quanto bene il modello sta apprendendo. Aspettati di vedere `train_loss` (loss sul batch corrente) e, periodicamente, `validation_loss` (loss sul set di validazione non visto). Entrambi dovrebbero generalmente diminuire nel tempo. Componenti specifici della loss (come `mel_loss`, `duration_loss`, `kl_loss`) potrebbero anche essere riportati a seconda dell'architettura del modello.
+    *   **Learning Rate:** Il learning rate corrente potrebbe essere stampato, specialmente se uno scheduler lo sta riducendo nel tempo.
+    *   **Timestamp/Velocità:** Tempo impiegato per step o epoca.
+-   **TensorBoard (Altamente Consigliato):** Se abilitato nella tua config, usa TensorBoard per il monitoraggio visivo.
+    *   **Avvio:** Apri un *nuovo* terminale (mantieni in esecuzione quello dell'addestramento), attiva lo stesso ambiente virtuale ed esegui:
+        ```bash
+        # Punta logdir alla output_directory specificata nella tua config
+        tensorboard --logdir ../checkpoints/my_yoruba_voice_run1
+        ```
+    *   **Accesso:** Apri l'URL fornito da TensorBoard (di solito `http://localhost:6006/`) nel tuo browser web.
+    *   **Visualizza:** Puoi vedere i grafici delle loss di addestramento e validazione nel tempo, gli schedule del learning rate e potenzialmente altre metriche.
+    *   **Ascolta i Sample Audio:** Molti framework registrano periodicamente sample audio sintetizzati dal set di validazione su TensorBoard (controlla la scheda `AUDIO`). Ascoltarli è il modo *migliore* per valutare qualitativamente il miglioramento del modello e identificare problemi come rumore, errori di pronuncia o output robotico.
+-   **Directory di Output:** Controlla la `output_directory` specificata nella tua config (`../checkpoints/my_yoruba_voice_run1`). Dovrebbe contenere:
+    *   Checkpoint del modello salvati (file `.pth`, `.pt`, `.ckpt`).
+    *   File di log (`train.log`, ecc.).
+    *   Copie del file di configurazione utilizzato.
+    *   File di evento TensorBoard (di solito in una sottodirectory `logs` o `events`).
+    *   Possibilmente sample audio sintetizzati.
+
+### 5.3. Comprendere i Checkpoint
+
+-   **Cosa sono:** I checkpoint sono istantanee dello stato del modello (tutti i suoi pesi appresi e potenzialmente lo stato dell'optimizer) salvate a intervalli specifici durante l'addestramento.
+-   **Perché sono importanti:**
+    *   **Riprendere l'Addestramento:** Consentono di continuare l'addestramento se viene interrotto (a causa di crash, interruzioni di corrente o arresto manuale).
+    *   **Valutare i Progressi:** Puoi usare i checkpoint di diverse fasi per sintetizzare audio e vedere come il modello è evoluto.
+    *   **Selezionare il Modello Migliore:** La validation loss aiuta a identificare i buoni checkpoint, ma il modello *migliore* viene spesso scelto ascoltando l'audio sintetizzato da diversi checkpoint promettenti vicini alla validation loss più bassa. A volte un checkpoint leggermente precedente suona meglio di quello con la loss in assoluto più bassa.
+-   **Frequenza di Salvataggio:** Configura il `save_checkpoint_interval` nella tua config. Salvare troppo spesso consuma spazio su disco; salvare troppo raramente rischia di perdere progressi significativi se si verifica un crash. Salvare ogni qualche migliaio di step o una volta per epoca è comune. Molti framework salvano anche automaticamente il checkpoint "migliore" in base alla validation loss.
+
+### 5.4. Riprendere un Addestramento Interrotto
+
+-   Se il tuo addestramento si arresta inaspettatamente o lo fermi manualmente, di solito puoi riprendere dall'ultimo checkpoint salvato.
+-   Trova il percorso dell'ultimo file di checkpoint nella tua directory di output (ad esempio `../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth` o `latest_checkpoint.pth`).
+-   Usa l'argomento di ripresa del framework quando avvii nuovamente lo script di addestramento. Il nome dell'argomento varia:
+    ```bash
+    # Esempio con --resume_checkpoint
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --resume_checkpoint ../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth
+
+    # Esempio con --restore_path o --resume_path
+    python train.py --config ../my_configs/my_yoruba_voice_ft_config.yaml --restore_path ../checkpoints/my_yoruba_voice_run1/ckpt_step_50000.pth
+    ```
+-   Lo script dovrebbe caricare i pesi del modello e lo stato dell'optimizer dal checkpoint e continuare l'addestramento da quel punto.
+
+### 5.5. Quando Interrompere l'Addestramento
+
+-   **Limite di Epoche:** L'addestramento si arresta automaticamente quando viene raggiunto il numero massimo di `epochs` specificato nella config.
+-   **Early Stopping:** Monitora la `validation_loss`. Se smette di diminuire e inizia ad aumentare costantemente per un periodo prolungato (ad esempio, su diversi intervalli di validazione), il modello potrebbe iniziare a fare overfitting. Potresti considerare di interrompere l'addestramento manualmente intorno al punto in cui la validation loss era più bassa.
+-   **Valutazione Qualitativa:** Ascolta regolarmente i sample audio di validazione generati in TensorBoard o sintetizza manualmente sample usando checkpoint recenti. Interrompi l'addestramento quando sei soddisfatto della qualità e della stabilità dell'audio, anche se la loss sta ancora diminuendo leggermente. Un ulteriore addestramento potrebbe non produrre miglioramenti percepibili o potrebbe persino degradare la qualità.
+
+---
+
+## 6. Fine-tuning vs. Addestramento da Zero
+
+### 6.1. Scegliere il Tuo Approccio
+
+Quando avvii un progetto TTS, una delle decisioni più importanti è se effettuare il fine-tuning di un modello esistente o addestrarne uno nuovo da zero. Questa tabella ti aiuta a decidere quale approccio è il migliore per la tua situazione specifica:
+
+| Fattore | Fine-tuning | Addestramento da Zero |
+|:-------|:------------|:----------------------|
+| **Dimensione del Dataset** | Funziona bene con dataset più piccoli (5-20 ore)<br>Può produrre buoni risultati anche con solo 1-2 ore per alcune voci | Tipicamente richiede dataset più grandi (30+ ore)<br>Meno di 20 ore spesso porta a una qualità scadente |
+| **Somiglianza Vocale** | Migliore quando la tua voce target è simile alle voci nei dati di addestramento del modello pre-addestrato | Necessario quando la tua voce target è molto unica o significativamente diversa dai modelli pre-addestrati disponibili |
+| **Lingua** | Funziona bene se si effettua il fine-tuning nella stessa lingua<br>Può funzionare per il cross-linguale con un'attenta preparazione | Richiesto per lingue senza modelli pre-addestrati disponibili<br>Migliore per catturare la fonetica specifica della lingua |
+| **Tempo di Addestramento** | Molto più veloce (giorni invece di settimane)<br>Richiede meno epoche per convergere | Tempo di addestramento significativamente più lungo<br>Può richiedere da 2 a 5 volte più epoche |
+| **Requisiti Hardware** | Requisiti GPU simili ma per meno tempo<br>Può spesso usare batch size più piccoli | Necessita di accesso GPU sostenuto per periodi più lunghi<br>Può beneficiare maggiormente di setup multi-GPU |
+| **Potenziale di Qualità** | Può raggiungere rapidamente un'eccellente qualità<br>Può ereditare i limiti del modello base | Massima flessibilità e qualità potenziale<br>Nessun vincolo da addestramenti precedenti |
+| **Stabilità** | Processo di addestramento generalmente più stabile<br>Meno soggetto a collasso o non-convergenza | Più sensibile agli iperparametri<br>Rischio più elevato di instabilità dell'addestramento |
+
+#### Quando Scegliere il Fine-tuning
+
+Il fine-tuning è generalmente consigliato quando:
+- Hai dati limitati (meno di 20 ore)
+- Hai bisogno di risultati più rapidi
+- La tua voce/lingua target è ragionevolmente simile ai modelli pre-addestrati disponibili
+- Hai risorse computazionali limitate
+- Sei nuovo all'addestramento TTS (il fine-tuning è più indulgente)
+
+#### Quando Scegliere l'Addestramento da Zero
+
+L'addestramento da zero è migliore quando:
+- Hai dati abbondanti (30+ ore)
+- La tua voce target è altamente unica o ha caratteristiche non rappresentate nei modelli pre-addestrati
+- Stai lavorando con una lingua scarsamente supportata dai modelli esistenti
+- Hai bisogno del massimo controllo su tutti gli aspetti del modello
+- Hai accesso a risorse computazionali significative
+- Stai costruendo un foundation model su cui altri effettueranno il fine-tuning
+
+### 6.2. Specifiche del Fine-tuning
+
+Il fine-tuning sfrutta un potente modello pre-addestrato e lo adatta al tuo dataset specifico (speaker, lingua, stile). È solitamente più veloce e richiede meno dati rispetto all'addestramento da zero.
+
+#### L'Obiettivo
+
+-   Trasferire le capacità generali di sintesi vocale (come la comprensione della mappatura testo-suono, la prosodia di base) dal grande dataset su cui è stato addestrato il modello base, specializzando al contempo l'identità vocale e potenzialmente l'accento/stile per corrispondere al tuo dataset più piccolo e specifico.
+
+### 6.2. Differenze Chiave di Configurazione (Riepilogo dal Setup)
+
+-   **`pretrained_model_path`:** DEVI fornire il percorso al file di checkpoint del modello pre-addestrato nella tua configurazione.
+-   **`fine_tuning: True`:** Assicurati che qualsiasi flag che indichi la modalità di fine-tuning sia abilitato se il framework lo richiede.
+-   **Learning Rate:** Inizia con un learning rate *più basso* di quello tipicamente usato per l'addestramento da zero (ad esempio `1e-5`, `2e-5`, `5e-5`). Un learning rate elevato può distruggere le preziose informazioni apprese dal modello pre-addestrato.
+-   **Batch Size:** Può spesso essere simile all'addestramento da zero, regola in base alla VRAM.
+-   **Epoche:** Il numero di epoche richiesto per il fine-tuning è solitamente significativamente inferiore rispetto all'addestramento da zero, ma dipende comunque dalla dimensione del dataset e dalla qualità desiderata. Monitora attentamente la validation loss e i sample audio.
+
+### 6.3. Possibili Strategie (Dipendenti dal Framework)
+
+-   **Fine-tuning dell'Intera Rete:** L'approccio predefinito è spesso aggiornare i pesi attraverso l'intera rete, ma con un learning rate basso.
+-   **Congelare i Layer:** Alcuni framework consentono di congelare parti della rete (ad esempio il text encoder o il duration predictor) inizialmente e di addestrare solo componenti specifici (come gli speaker embedding o il decoder). Questo può talvolta aiutare a preservare i punti di forza del modello base adattando al contempo aspetti specifici. Controlla la documentazione del tuo framework per opzioni `--freeze_layers` o simili.
+-   **Ignorare i Layer:** Quando carichi il modello pre-addestrato, potresti voler usare `ignore_layers` (o `reinitialize_layers`) come il layer di output finale o il layer di speaker embedding, specialmente se il tuo dataset ha un numero di speaker diverso dal modello pre-addestrato.
+
+### 6.4. Monitorare il Fine-tuning
+
+-   **Rapido Miglioramento Iniziale:** Dovresti vedere la validation loss calare relativamente in fretta all'inizio, man mano che il modello si adatta alla voce target.
+-   **Concentrati sulla Qualità Audio:** Presta molta attenzione ai sample di validazione sintetizzati. L'identità vocale si sta spostando verso il tuo speaker target? Il parlato è chiaro e stabile? Il fine-tuning riguarda spesso più la qualità percettiva che il raggiungimento del valore di loss minimo assoluto.
+
+---
+
+## 7. Guida Completa alla Risoluzione dei Problemi
+
+Addestrare modelli TTS può essere impegnativo, con molti potenziali problemi. Questa sezione fornisce soluzioni per i problemi comuni che potresti incontrare.
+
+### 7.1. Messaggi di Errore Comuni e Soluzioni
+
+| Messaggio di Errore | Possibili Cause | Soluzioni |
+|:--------------|:----------------|:----------|
+| `CUDA out of memory` | • Batch size troppo grande<br>• Modello troppo grande per la GPU<br>• Memory leak | • Riduci il batch size<br>• Abilita il gradient checkpointing<br>• Usa il mixed precision training<br>• Riduci la lunghezza della sequenza |
+| `RuntimeError: Expected tensor for argument #1 'indices' to have scalar type Long` | • Tipo di dato errato nel dataset<br>• Tipi di tensore incompatibili | • Controlla il preprocessing dei dati<br>• Assicurati che tutti i tensori abbiano il dtype corretto<br>• Aggiungi una conversione esplicita del tipo |
+| `ValueError: too many values to unpack` | • Discrepanza tra gli output del modello e le aspettative della loss function<br>• Formato dei dati errato | • Controlla la struttura dell'output del modello<br>• Verifica l'implementazione della loss function<br>• Esegui il debug degli output del data loader |
+| `FileNotFoundError: [Errno 2] No such file or directory` | • Percorsi errati nella config<br>• File di dati mancanti | • Verifica tutti i percorsi dei file<br>• Controlla l'integrità del file manifest<br>• Assicurati che i dati siano scaricati/estratti |
+| `KeyError: 'speaker_id'` | • Informazioni sullo speaker mancanti<br>• Formato del dataset errato | • Controlla il formato del dataset<br>• Verifica il file di mapping dello speaker<br>• Aggiungi le informazioni sullo speaker al manifest |
+| `Loss is NaN` | • Learning rate troppo alto<br>• Inizializzazione instabile<br>• Esplosione del gradiente | • Riduci il learning rate<br>• Aggiungi il gradient clipping<br>• Controlla la divisione per zero<br>• Normalizza i dati di input |
+| `ModuleNotFoundError: No module named 'X'` | • Dipendenza mancante<br>• Problema dell'ambiente | • Installa il pacchetto mancante<br>• Controlla l'ambiente virtuale<br>• Verifica le versioni dei pacchetti |
+| `RuntimeError: expected scalar type Float but found Double` | • Tipi di tensore incoerenti | • Aggiungi `.float()` ai tensori<br>• Controlla il preprocessing dei dati<br>• Standardizza il dtype in tutto il modello |
+
+### 7.2. Problemi di Qualità dell'Addestramento
+
+| Sintomo | Possibili Cause | Soluzioni |
+|:--------|:----------------|:----------|
+| **Audio Robotico/Ronzante** | • Problemi del vocoder<br>• Addestramento insufficiente<br>• Preprocessing audio scadente | • Addestra il vocoder più a lungo<br>• Controlla la normalizzazione audio<br>• Verifica la coerenza del sampling rate |
+| **Salto/Ripetizione di Parole** | • Problemi di attention<br>• Addestramento instabile<br>• Dati insufficienti | • Usa la guided attention loss<br>• Aggiungi più varietà di dati<br>• Riduci il learning rate<br>• Controlla i silenzi lunghi nei dati |
+| **Pronuncia Errata** | • Problemi di normalizzazione del testo<br>• Errori fonemici<br>• Discrepanza linguistica | • Migliora il preprocessing del testo<br>• Usa input basato sui fonemi<br>• Aggiungi un dizionario di pronuncia |
+| **Perdita dell'Identità dello Speaker** | • Overfitting verso lo speaker dominante<br>• Speaker embedding deboli<br>• Dati insufficienti sullo speaker | • Bilancia i dati degli speaker<br>• Aumenta la dimensione dello speaker embedding<br>• Usa la speaker adversarial loss |
+| **Convergenza Lenta** | • Problemi di learning rate<br>• Inizializzazione scadente<br>• Dataset complesso | • Prova diversi schedule del LR<br>• Usa il transfer learning<br>• Semplifica inizialmente il dataset |
+| **Addestramento Instabile** | • Varianza del batch<br>• Valori anomali nel dataset<br>• Problemi dell'optimizer | • Usa la gradient accumulation<br>• Pulisci i sample anomali<br>• Prova diversi optimizer |
+
+### 7.3. Problemi Specifici del Framework
+
+#### Coqui TTS
+```
+# Error: "RuntimeError: Error in applying gradient to param_name"
+# Solution: Check for NaN values in your dataset or reduce learning rate
+python -c "import torch; torch.autograd.set_detect_anomaly(True)"  # Run before training to debug
+
+# Error: "ValueError: Tacotron training requires `r` > 1"
+# Solution: Set reduction factor correctly in config
+# Example fix in config.json:
+"r": 2  # Try values between 2-5
+```
+
+#### ESPnet
+```
+# Error: "TypeError: forward() missing 1 required positional argument: 'feats'"
+# Solution: Check data formatting and ensure feats are provided
+# Debug data loading:
+python -c "from espnet2.train.dataset import ESPnetDataset; dataset = ESPnetDataset(...); print(dataset[0])"
+```
+
+#### VITS/StyleTTS
+```
+# Error: "RuntimeError: expected scalar type Half but found Float"
+# Solution: Ensure consistent precision throughout model
+# Add to your training script:
+model = model.half()  # If using mixed precision
+# OR
+model = model.float()  # If not using mixed precision
+```
+
+### 7.4. Problemi di Hardware e Ambiente
+
+1. **Frammentazione della Memoria GPU**
+   - **Sintomo**: Errori OOM dopo diverse ore di addestramento nonostante VRAM sufficiente
+   - **Soluzione**: Riavvia periodicamente l'addestramento dal checkpoint, usa batch più piccoli
+
+2. **Colli di Bottiglia della CPU**
+   - **Sintomo**: L'utilizzo della GPU fluttua o rimane basso
+   - **Soluzione**: Aumenta num_workers nel DataLoader, usa storage più veloce, pre-memorizza i dataset nella cache
+
+3. **Colli di Bottiglia dell'I/O su Disco**
+   - **Sintomo**: L'addestramento si blocca periodicamente durante il caricamento dei dati
+   - **Soluzione**: Usa storage SSD, aumenta il prefetch factor, memorizza il dataset in RAM
+
+4. **Conflitti di Ambiente**
+   - **Sintomo**: Crash misteriosi o errori di import
+   - **Soluzione**: Usa ambienti isolati (conda/venv), controlla la compatibilità CUDA/PyTorch
+
+### 7.5. Strategie di Debugging
+
+1. **Isola il Problema**
+   ```bash
+   # Testa il caricamento dei dati separatamente
+   python -c "from your_framework import DataLoader; loader = DataLoader(...); next(iter(loader))"
+   
+   # Testa il forward pass con dati fittizi
+   python -c "import torch; from your_model import Model; model = Model(); x = torch.randn(1, 100); model(x)"
+   ```
+
+2. **Semplifica per Identificare i Problemi**
+   - Addestra su un piccolo sottoinsieme (10-20 sample)
+   - Disabilita temporaneamente la data augmentation
+   - Prova prima con un singolo speaker
+
+3. **Visualizza gli Output Intermedi**
+   - Traccia gli allineamenti di attention
+   - Visualizza i mel spectrogram nelle diverse fasi
+   - Monitora le norme dei gradienti
+
+4. **Abilita il Logging Verboso**
+   ```bash
+   # Aggiungi al tuo script di addestramento
+   import logging
+   logging.basicConfig(level=logging.DEBUG)
+   ```
+
+5. **Usa il Profiling di TensorBoard**
+   ```python
+   # Aggiungi al tuo codice di addestramento
+   from torch.profiler import profile, record_function
+   with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+       with record_function("model_inference"):
+           # Il tuo forward pass
+   print(prof.key_averages().table())
+   ```
+
+---
+
+Con l'addestramento avviato e monitorato, il passo successivo, dopo aver selezionato un buon checkpoint, è usare il modello per generare il parlato su nuovo testo.
+
+**Passo Successivo:** [Inferenza](./4_INFERENCE.md){: .btn .btn-primary} | 
+[Torna in Cima](#top){: .btn .btn-primary}

--- a/languages/it/guides/4_INFERENCE.md
+++ b/languages/it/guides/4_INFERENCE.md
@@ -1,0 +1,426 @@
+# Guida 4: Inferenza - Generare il Parlato con il Tuo Modello
+
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Precedente: Addestramento del Modello](./3_MODEL_TRAINING.md){: .btn .btn-primary} | [Passo Successivo: Packaging e Condivisione](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+
+Hai addestrato con successo o effettuato il fine-tuning di un modello TTS e selezionato un checkpoint promettente! Ora, usiamo quel modello per convertire nuovo testo in audio parlato, un processo chiamato **inferenza** o **sintesi**.
+
+---
+
+## 7. Inferenza: Sintetizzare il Parlato
+
+Questa sezione spiega come eseguire il processo di inferenza usando il tuo modello addestrato.
+
+### 7.1. Individuare lo Script di Inferenza e il Checkpoint Migliore
+
+-   **Script di Inferenza:** Trova lo script Python all'interno del tuo framework TTS progettato per generare audio. I nomi comuni includono `inference.py`, `synthesize.py`, `infer.py`, `tts.py`.
+-   **Checkpoint Migliore:** Identifica il percorso del checkpoint del modello (`.pth`, `.pt`, `.ckpt`) che vuoi usare. Questo è tipicamente quello salvato come `best_model.pth` (in base alla validation loss) o un altro checkpoint che hai selezionato ascoltando i sample di validazione durante l'addestramento. Sarà collocato all'interno della tua directory di output dell'addestramento (ad esempio `../checkpoints/my_yoruba_voice_run1/best_model.pth`).
+-   **File di Configurazione:** Avrai quasi sempre bisogno del file di configurazione (`.yaml`, `.json`) che è stato usato *durante l'addestramento* del checkpoint che stai utilizzando. Lo script di inferenza ne ha bisogno per conoscere l'architettura del modello, i parametri audio (come il sampling rate) e altre impostazioni. Spesso, una copia della config viene salvata insieme ai checkpoint.
+
+### 7.2. Inferenza Base di una Singola Frase
+
+-   **Obiettivo:** Generare audio per un singolo testo fornito direttamente tramite la riga di comando.
+-   **Struttura del Comando:** Gli argomenti esatti varieranno, ma un comando tipico si presenta così:
+
+    ```bash
+    # Attiva prima il tuo ambiente virtuale!
+    # Comando di esempio:
+    python inference.py \
+      --config ../checkpoints/my_yoruba_voice_run1/config.yaml \
+      --checkpoint_path ../checkpoints/my_yoruba_voice_run1/best_model.pth \
+      --text "Hello, this is a test of my custom trained voice." \
+      --output_wav_path ./output_sample.wav
+      # Argomenti opzionali/dipendenti dal framework qui sotto:
+      # --speaker_id "main_speaker"  # Necessario per modelli multi-speaker
+      # --device "cuda"              # Per specificare l'uso della GPU (spesso predefinito)
+    ```
+-   **Argomenti Chiave:**
+    *   `--config` o `-c`: Percorso al file di configurazione dell'addestramento.
+    *   `--checkpoint_path` o `--model_path` o `-m`: Percorso al file di checkpoint del modello.
+    *   `--text` o `-t`: La frase di input che vuoi sintetizzare. Ricorda di racchiuderla tra virgolette.
+    *   `--output_wav_path` o `--out_path` o `-o`: Il percorso e il nome file desiderati per il file WAV generato.
+    *   `--speaker_id` o `--spk`: **Richiesto** se hai addestrato un modello multi-speaker. Fornisci l'esatto speaker ID usato nei tuoi file manifest per la voce desiderata. Per i modelli a singolo speaker, questo potrebbe essere opzionale o ignorato.
+    *   `--device`: Spesso opzionale, predefinito a `cuda` se disponibile, altrimenti `cpu`. L'inferenza è molto più veloce su GPU.
+
+-   **Esecuzione:** Esegui il comando. Caricherà il modello, elaborerà il testo, genererà la forma d'onda audio e la salverà nel file di output specificato. Ascolta il file WAV di output per verificare la qualità.
+
+### 7.3. Inferenza in Batch (Sintetizzare da un File)
+
+-   **Obiettivo:** Generare audio per più frasi elencate in un file di testo, salvando ciascuna come file WAV separato.
+-   **Prepara il File di Input:** Crea un file di testo semplice (ad esempio `sentences.txt`) dove ogni riga contiene una frase che vuoi sintetizzare:
+    ```text
+    Questa è la prima frase.
+    Ecco un'altra frase da sintetizzare.
+    Il modello dovrebbe gestire segni di punteggiatura diversi, come le domande?
+    E anche le esclamazioni!
+    ```
+-   **Struttura del Comando:** Molti framework forniscono uno script separato o argomenti specifici per l'elaborazione batch.
+
+    ```bash
+    # Comando di esempio (il nome dello script e gli argomenti possono variare):
+    python inference_batch.py \
+      --config ../checkpoints/my_yoruba_voice_run1/config.yaml \
+      --checkpoint_path ../checkpoints/my_yoruba_voice_run1/best_model.pth \
+      --input_file sentences.txt \
+      --output_dir ./generated_batch_audio/
+      # Argomenti opzionali/dipendenti dal framework qui sotto:
+      # --speaker_id "main_speaker"  # Necessario per modelli multi-speaker
+      # --device "cuda"
+    ```
+-   **Argomenti Chiave:**
+    *   `--input_file` o `--text_file`: Percorso al file di testo contenente le frasi (una per riga).
+    *   `--output_dir` o `--out_dir`: Percorso alla directory dove devono essere salvati i file WAV generati. Assicurati che questa directory esista o che lo script la crei. I nomi dei file di output sono spesso basati sul numero di riga o sul testo di input stesso (ad esempio `output_0.wav`, `output_1.wav`).
+    *   Gli altri argomenti (`--config`, `--checkpoint_path`, `--speaker_id`, `--device`) sono tipicamente gli stessi dell'inferenza di una singola frase.
+
+-   **Esecuzione:** Esegui il comando. Lo script itererà su ogni riga del file di input, sintetizzerà l'audio e salverà i risultati nella directory di output specificata.
+
+### 7.4. Inferenza di Modelli Multi-Speaker
+
+-   Come menzionato sopra, se il tuo modello è stato addestrato su dati di più speaker, **devi** specificare quale voce di speaker vuoi usare durante l'inferenza.
+-   Usa l'argomento `--speaker_id` (o equivalente), fornendo l'esatto ID che corrisponde allo speaker desiderato nei tuoi file manifest di addestramento (ad esempio `speaker0`, `mary_smith`, `yoruba_male_spk1`).
+-   Se ometti lo speaker ID per un modello multi-speaker, lo script potrebbe fallire, usare per impostazione predefinita uno speaker specifico (spesso lo speaker 0) o produrre risultati mediati/confusi.
+
+### 7.5. Controlli di Inferenza Avanzati (Dipendenti dal Framework)
+
+-   Alcuni modelli e framework TTS avanzati offrono controlli aggiuntivi durante l'inferenza, spesso passati come argomenti da riga di comando o parametri in un'API Python:
+    *   **Velocità del Parlato/Speed:** Argomenti come `--speed` o `--length_scale` potrebbero consentirti di far parlare la voce più velocemente o più lentamente (ad esempio, `1.0` è normale, `<1.0` è più veloce, `>1.0` è più lento).
+    *   **Controllo del Pitch:** Meno comune, ma alcuni modelli potrebbero consentire regolazioni del pitch.
+    *   **Controllo di Stile/Emozione:** Se il modello è stato addestrato con style token o capacità di audio di riferimento (come StyleTTS2 o modelli con style embedding), potresti fornire argomenti come `--style_text` o `--style_wav` per influenzare la prosodia o l'emozione dell'output.
+    *   **Impostazioni del Vocoder (se applicabile):** Per i modelli più vecchi in stile Tacotron2 o altri che usano modelli vocoder separati (come HiFi-GAN, MelGAN), potrebbero esserci impostazioni relative al vocoder (ad esempio la forza del denoising).
+    *   **Diffusion Models:** Per i modelli TTS basati su diffusion, potrebbero essere disponibili parametri che controllano il numero di diffusion step (scambiando qualità con velocità).
+-   **Consulta la Documentazione:** Fai sempre riferimento alla documentazione del tuo specifico framework TTS o all'help dello script di inferenza (`python inference.py --help`) per vedere quali controlli sono disponibili.
+
+### 7.6. Potenziali Problemi di Inferenza
+
+-   **CUDA Out-of-Memory (OOM):** Anche se l'addestramento ha funzionato, frasi molto lunghe durante l'inferenza potrebbero consumare più memoria. Prova frasi più corte o verifica se il framework offre opzioni per la sintesi segmentata. L'esecuzione su CPU (`--device cpu`) usa la RAM di sistema ma è significativamente più lenta.
+-   **Discrepanza Modello/Config:** Usare un checkpoint con il file di configurazione errato è un errore comune, che porta a fallimenti di caricamento o output incomprensibile. Assicurati che corrispondano alla stessa esecuzione di addestramento.
+-   **Speaker ID Errato:** Fornire uno speaker ID inesistente per i modelli multi-speaker causerà errori.
+-   **Problemi di Qualità (Rumore, Instabilità):** Se la qualità dell'output è scarsa, rivedi la Guida 1 (Preparazione dei Dati) e la Guida 3 (Addestramento del Modello). Potrebbe indicare problemi con la qualità dei dati, addestramento insufficiente o scelta di un checkpoint subottimale.
+
+---
+
+## 8. Valutazione e Deployment del Modello
+
+### 8.1. Valutare la Qualità del Modello TTS
+
+Sebbene i test di ascolto soggettivi siano il gold standard per la valutazione TTS, esistono anche metriche oggettive che possono aiutare a quantificare le prestazioni del tuo modello:
+
+#### Metriche di Valutazione Oggettive
+
+| Metrica | Cosa Misura | Strumenti/Implementazione | Interpretazione |
+|:-------|:-----------------|:---------------------|:---------------|
+| **MOS (Mean Opinion Score)** | Qualità percepita complessiva | Valutatori umani giudicano i sample su una scala da 1 a 5 | Più alto è meglio; standard del settore ma richiede valutatori umani |
+| **PESQ (Perceptual Evaluation of Speech Quality)** | Qualità audio rispetto a un riferimento | Disponibile in Python tramite `pypesq` | Intervallo: da -0.5 a 4.5; più alto è meglio |
+| **STOI (Short-Time Objective Intelligibility)** | Intelligibilità del parlato | Disponibile in Python tramite `pystoi` | Intervallo: da 0 a 1; più alto è meglio |
+| **Character/Word Error Rate (CER/WER)** | Intelligibilità tramite ASR | Esegui l'ASR sul parlato sintetizzato e confronta con il testo di input | Più basso è meglio; misura se le parole sono pronunciate correttamente |
+| **Mel Cepstral Distortion (MCD)** | Distanza spettrale dal riferimento | Implementazione personalizzata con librosa | Più basso è meglio; tipicamente 2-8 per i sistemi TTS |
+| **F0 RMSE** | Accuratezza del pitch | Implementazione personalizzata con librosa | Più basso è meglio; misura l'accuratezza del contorno del pitch |
+| **Voicing Decision Error** | Accuratezza voiced/unvoiced | Implementazione personalizzata | Più basso è meglio; misura se parlato/silenzio è collocato correttamente |
+
+#### Approccio Pratico alla Valutazione
+
+1. **Prepara un Test Set**: Crea un insieme di frasi di test diverse non viste durante l'addestramento
+   ```
+   # Esempio di test_sentences.txt
+   Questa è una semplice frase dichiarativa.
+   Questa è una frase interrogativa?
+   Wow! Questa è una frase esclamativa!
+   Questa frase contiene numeri come 123 e simboli come %.
+   Questa è una frase molto più lunga che prosegue per parecchio tempo, mettendo alla prova la capacità del modello di mantenere la coerenza e una prosodia corretta su enunciati più lunghi con molteplici proposizioni e locuzioni.
+   ```
+
+2. **Genera i Sample**: Usa il tuo modello per sintetizzare il parlato per tutte le frasi di test
+
+3. **Conduci Test di Ascolto**: Fai valutare i sample a più ascoltatori su:
+   - Naturalezza (scala 1-5)
+   - Qualità audio/artefatti (scala 1-5)
+   - Accuratezza della pronuncia (scala 1-5)
+   - Somiglianza dello speaker (scala 1-5, se si clona una voce specifica)
+
+4. **Implementa Metriche Oggettive**: Questo snippet Python dimostra come calcolare alcune metriche di base:
+
+   ```python
+   import numpy as np
+   import librosa
+   from pesq import pesq
+   from pystoi import stoi
+   import torch
+   from transformers import pipeline
+
+   def evaluate_tts_sample(generated_audio_path, reference_audio_path=None, original_text=None):
+       """Evaluate a TTS sample using various metrics."""
+       results = {}
+       
+       # Carica l'audio generato
+       y_gen, sr_gen = librosa.load(generated_audio_path, sr=None)
+       
+       # Statistiche audio di base
+       results["duration"] = librosa.get_duration(y=y_gen, sr=sr_gen)
+       results["rms_energy"] = np.sqrt(np.mean(y_gen**2))
+       
+       # Se l'audio di riferimento è disponibile, calcola le metriche di confronto
+       if reference_audio_path:
+           y_ref, sr_ref = librosa.load(reference_audio_path, sr=sr_gen)  # Allinea i sampling rate
+           
+           # Assicura la stessa lunghezza per il confronto
+           min_len = min(len(y_gen), len(y_ref))
+           y_gen_trim = y_gen[:min_len]
+           y_ref_trim = y_ref[:min_len]
+           
+           # PESQ (richiede audio a 16kHz o 8kHz)
+           if sr_gen in [8000, 16000]:
+               try:
+                   results["pesq"] = pesq(sr_gen, y_ref_trim, y_gen_trim, 'wb')
+               except Exception as e:
+                   results["pesq"] = f"Error: {str(e)}"
+           else:
+               results["pesq"] = "Requires 8kHz or 16kHz audio"
+           
+           # STOI
+           try:
+               results["stoi"] = stoi(y_ref_trim, y_gen_trim, sr_gen, extended=False)
+           except Exception as e:
+               results["stoi"] = f"Error: {str(e)}"
+       
+       # Se il testo originale è disponibile, esegui l'ASR e calcola WER/CER
+       if original_text:
+           try:
+               # Carica il modello ASR (richiede transformers e torch)
+               asr = pipeline("automatic-speech-recognition", model="openai/whisper-small")
+               
+               # Trascrivi l'audio generato
+               transcription = asr(generated_audio_path)["text"].strip().lower()
+               original_text = original_text.strip().lower()
+               
+               results["transcription"] = transcription
+               results["original_text"] = original_text
+               
+               # Calcolo semplice del character error rate
+               def cer(ref, hyp):
+                   ref, hyp = ref.lower(), hyp.lower()
+                   return levenshtein_distance(ref, hyp) / len(ref)
+               
+               def levenshtein_distance(s1, s2):
+                   if len(s1) < len(s2):
+                       return levenshtein_distance(s2, s1)
+                   if len(s2) == 0:
+                       return len(s1)
+                   previous_row = range(len(s2) + 1)
+                   for i, c1 in enumerate(s1):
+                       current_row = [i + 1]
+                       for j, c2 in enumerate(s2):
+                           insertions = previous_row[j + 1] + 1
+                           deletions = current_row[j] + 1
+                           substitutions = previous_row[j] + (c1 != c2)
+                           current_row.append(min(insertions, deletions, substitutions))
+                       previous_row = current_row
+                   return previous_row[-1]
+               
+               results["character_error_rate"] = cer(original_text, transcription)
+           except Exception as e:
+               results["asr_error"] = str(e)
+       
+       return results
+   ```
+
+### 8.2. Deployment dei Modelli TTS
+
+Una volta addestrato e valutato il tuo modello, potresti volerlo distribuire per un uso pratico. Ecco alcune opzioni di deployment:
+
+#### Considerazioni sul Deployment in Produzione
+
+Quando si passa dalla sperimentazione al deployment in produzione, considera questi importanti fattori:
+
+1. **Ottimizzazione del Modello**
+   - **Quantization**: Riduci la precisione del modello da FP32 a FP16 o INT8 per diminuire la dimensione e aumentare la velocità di inferenza
+   - **Pruning**: Rimuovi i pesi non necessari per creare modelli più piccoli e veloci
+   - **Knowledge Distillation**: Addestra un modello "studente" più piccolo per imitare il tuo modello "insegnante" più grande
+   - **ONNX Conversion**: Converti il tuo modello PyTorch/TensorFlow in formato ONNX per migliori prestazioni cross-platform
+
+2. **Ottimizzazione della Latenza**
+   - **Batch Processing**: Per applicazioni non in tempo reale, elabora più richieste in batch
+   - **Streaming Synthesis**: Per applicazioni in tempo reale, implementa l'elaborazione chunk-by-chunk
+   - **Caching**: Memorizza nella cache le frasi o le sequenze fonemiche richieste frequentemente
+   - **Hardware Acceleration**: Utilizza GPU/TPU per l'elaborazione parallela o hardware specializzato come NVIDIA TensorRT
+
+3. **Scalabilità**
+   - **Containerization**: Impacchetta il tuo modello e le dipendenze in container Docker
+   - **Kubernetes**: Orchestra più container per alta disponibilità e load balancing
+   - **Auto-scaling**: Regola automaticamente le risorse in base alla domanda
+   - **Queue Systems**: Implementa code di richieste (RabbitMQ, Kafka) per gestire i picchi di traffico
+
+4. **Monitoraggio e Manutenzione**
+   - **Performance Metrics**: Traccia latenza, throughput, tassi di errore e utilizzo delle risorse
+   - **Quality Monitoring**: Campiona e valuta periodicamente la qualità dell'output
+   - **A/B Testing**: Confronta diverse versioni del modello in produzione
+   - **Continuous Training**: Configura pipeline per riaddestrare i modelli con nuovi dati
+
+#### Esempio di Architettura di Deployment in Produzione
+
+```
+[Applicazioni Client] → [Load Balancer] → [API Gateway]
+                                             ↓
+[Validazione Richiesta] → [Rate Limiting] → [Autenticazione]
+                                             ↓
+[Coda Richieste] → [TTS Worker Pods (Kubernetes)] → [Cache Audio]
+                         ↓                              ↑
+                  [Container Modello TTS]               |
+                         ↓                              |
+                  [Post-Elaborazione Audio] → [Storage Audio]
+```
+
+#### Opzioni di Deployment Locale
+
+1. **Interfaccia a Riga di Comando**: L'approccio più semplice è creare uno script che incapsula il codice di inferenza:
+
+   ```python
+   # tts_cli.py
+   import argparse
+   import os
+   import torch
+   
+   # Importa qui i tuoi moduli specifici del modello
+   # from your_tts_framework import load_model, synthesize_text
+   
+   def main():
+       parser = argparse.ArgumentParser(description="Text-to-Speech CLI")
+       parser.add_argument("--text", type=str, required=True, help="Text to synthesize")
+       parser.add_argument("--model", type=str, required=True, help="Path to model checkpoint")
+       parser.add_argument("--config", type=str, required=True, help="Path to model config")
+       parser.add_argument("--output", type=str, default="output.wav", help="Output audio file path")
+       parser.add_argument("--speaker", type=str, default=None, help="Speaker ID for multi-speaker models")
+       args = parser.parse_args()
+       
+       # Carica il modello (l'implementazione dipende dal tuo framework)
+       model = load_model(args.model, args.config)
+       
+       # Sintetizza il parlato
+       audio = synthesize_text(model, args.text, speaker_id=args.speaker)
+       
+       # Salva l'audio
+       save_audio(audio, args.output)
+       print(f"Audio saved to {args.output}")
+   
+   if __name__ == "__main__":
+       main()
+   ```
+
+2. **Semplice UI Web**: Crea un'interfaccia web di base usando Flask o Gradio:
+
+   ```python
+   # app.py (esempio con Flask)
+   from flask import Flask, request, send_file, render_template
+   import os
+   import torch
+   import uuid
+   
+   # Importa qui i tuoi moduli specifici del modello
+   # from your_tts_framework import load_model, synthesize_text
+   
+   app = Flask(__name__)
+   
+   # Carica il modello all'avvio (per un'inferenza più veloce)
+   MODEL_PATH = "path/to/best_model.pth"
+   CONFIG_PATH = "path/to/config.yaml"
+   model = load_model(MODEL_PATH, CONFIG_PATH)
+   
+   @app.route('/')
+   def index():
+       return render_template('index.html')
+   
+   @app.route('/synthesize', methods=['POST'])
+   def synthesize():
+       text = request.form['text']
+       speaker_id = request.form.get('speaker_id', None)
+       
+       # Genera un nome file unico
+       output_file = f"static/audio/{uuid.uuid4()}.wav"
+       os.makedirs(os.path.dirname(output_file), exist_ok=True)
+       
+       # Sintetizza il parlato
+       audio = synthesize_text(model, text, speaker_id=speaker_id)
+       
+       # Salva l'audio
+       save_audio(audio, output_file)
+       
+       return {'audio_path': output_file}
+   
+   if __name__ == '__main__':
+       app.run(host='0.0.0.0', port=5000, debug=True)
+   ```
+
+3. **Interfaccia Gradio** (Ancora più semplice):
+
+   ```python
+   import gradio as gr
+   import torch
+   
+   # Importa qui i tuoi moduli specifici del modello
+   # from your_tts_framework import load_model, synthesize_text
+   
+   # Carica il modello
+   MODEL_PATH = "path/to/best_model.pth"
+   CONFIG_PATH = "path/to/config.yaml"
+   model = load_model(MODEL_PATH, CONFIG_PATH)
+   
+   def tts_function(text, speaker_id=None):
+       # Sintetizza il parlato
+       audio = synthesize_text(model, text, speaker_id=speaker_id)
+       sampling_rate = 22050  # Adatta al rate del tuo modello
+       return (sampling_rate, audio)
+   
+   # Crea l'interfaccia Gradio
+   iface = gr.Interface(
+       fn=tts_function,
+       inputs=[
+           gr.Textbox(lines=3, placeholder="Enter text to synthesize..."),
+           gr.Dropdown(choices=["speaker1", "speaker2"], label="Speaker", visible=True)  # Per modelli multi-speaker
+       ],
+       outputs=gr.Audio(type="numpy"),
+       title="Text-to-Speech Demo",
+       description="Enter text and generate speech using a custom TTS model."
+   )
+   
+   iface.launch(server_name="0.0.0.0", server_port=7860)
+   ```
+
+#### Opzioni di Deployment Cloud
+
+Per l'uso in produzione, considera queste opzioni:
+
+1. **Hugging Face Spaces**: Carica il tuo modello su Hugging Face e crea un'app Gradio o Streamlit
+2. **REST API**: Incapsula il tuo modello in un'applicazione FastAPI o Flask e distribuiscilo su servizi cloud
+3. **Serverless Functions**: Per modelli leggeri, distribuiscili come funzioni serverless (AWS Lambda, Google Cloud Functions)
+4. **Docker Containers**: Impacchetta il tuo modello e le dipendenze in un container Docker per un deployment coerente
+
+#### Ottimizzazione delle Prestazioni
+
+Per migliorare la velocità e l'efficienza dell'inferenza:
+
+1. **Model Quantization**: Converti i pesi del modello a una precisione inferiore (FP16 o INT8)
+   ```python
+   # Esempio di conversione FP16 con PyTorch
+   model = model.half()  # Convert to FP16
+   ```
+
+2. **Model Pruning**: Rimuovi i pesi non necessari per creare modelli più piccoli
+3. **ONNX Conversion**: Converti i modelli PyTorch in formato ONNX per un'inferenza più veloce
+   ```python
+   # Esempio di export ONNX
+   import torch.onnx
+   
+   # Esporta il modello
+   torch.onnx.export(model,               # model being run
+                     dummy_input,         # model input (or a tuple for multiple inputs)
+                     "model.onnx",        # where to save the model
+                     export_params=True,  # store the trained parameter weights inside the model file
+                     opset_version=11,    # the ONNX version to export the model to
+                     do_constant_folding=True)  # optimization
+   ```
+
+4. **Batch Processing**: Elabora più input testuali contemporaneamente per un throughput più elevato
+5. **Caching**: Memorizza nella cache gli output richiesti frequentemente per evitare la rigenerazione
+
+Ora che puoi generare il parlato usando il tuo modello addestrato, il passo logico successivo è organizzare correttamente i file del modello per usi futuri, condivisione o deployment.
+
+**Passo Successivo:** [Packaging e Condivisione](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+[Torna in Cima](#top){: .btn .btn-primary}

--- a/languages/it/guides/5_PACKAGING_AND_SHARING.md
+++ b/languages/it/guides/5_PACKAGING_AND_SHARING.md
@@ -1,0 +1,129 @@
+# Guida 5: Packaging e Condivisione del Tuo Modello TTS
+
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Precedente: Inferenza](./4_INFERENCE.md){: .btn .btn-primary} |  | [Passo Successivo: Risoluzione dei Problemi e Risorse](./6_TROUBLESHOOTING_AND_RESOURCES.md){: .btn .btn-primary} | 
+
+
+Hai addestrato un modello e puoi generare il parlato con esso. Congratulazioni! Per assicurarti che il tuo modello sia utilizzabile in futuro (da te stesso o da altri) e per facilitare la riproducibilità, un packaging e una documentazione appropriati sono essenziali.
+
+---
+
+## 9. Packaging del Tuo Modello Addestrato
+
+Pensa al tuo modello addestrato non solo come a un singolo file `.pth`, ma come a un pacchetto completo contenente tutto il necessario per comprenderlo e utilizzarlo.
+
+### 9.1. Organizza i File del Tuo Modello
+
+Crea una struttura di directory pulita e autonoma per ogni modello addestrato distinto o versione significativa. Questo rende facile trovare tutto in seguito.
+
+**Esempio di Struttura:**
+
+```
+my_tts_model_packages/
+└── yoruba_male_v1.0/         # Nome descrittivo per questo pacchetto del modello
+    ├── checkpoints/          # Directory per i pesi del modello
+    │   ├── best_model.pth    # Checkpoint con la validation loss più bassa (o la migliore qualità percepita)
+    │   └── last_model.pth    # Checkpoint dalla fine assoluta dell'addestramento (opzionale, ma a volte utile)
+    │
+    ├── config.yaml           # Il file di configurazione ESATTO usato per addestrare QUESTO checkpoint
+    │
+    ├── training_info.md      # Opzionale: Un file con log/note dettagliati dell'addestramento
+    │   ├── train_list.txt    # Copia del file manifest di addestramento usato
+    │   └── val_list.txt      # Copia del file manifest di validazione usato
+    │
+    ├── samples/              # Directory con audio di esempio generati da questo modello
+    │   ├── sample_short_sentence.wav
+    │   ├── sample_question.wav
+    │   └── sample_longer_paragraph.wav
+    │
+    └── README.md             # Essenziale: Documentazione leggibile dall'uomo per questo specifico pacchetto del modello
+```
+
+**Componenti Chiave Spiegati:**
+
+*   **`checkpoints/`**: Contiene i pesi effettivi del modello. Includi sempre il checkpoint ritenuto 'migliore' (sia per loss che per test di ascolto). Includere il checkpoint finale è anch'essa una buona pratica.
+*   **`config.yaml` (o `.json`)**: Assolutamente critico. Questo file definisce l'architettura del modello e i parametri necessari per caricare e utilizzare correttamente il checkpoint. Senza di esso, il checkpoint è spesso inutilizzabile. Assicurati che sia la config *esatta* usata per i checkpoint inclusi.
+*   **`training_info.md` / Manifest (Opzionale ma Consigliato):** Memorizzare i manifest aiuta a tracciare esattamente su quali dati è stato addestrato il modello. Un `training_info.md` può contenere note sull'esecuzione dell'addestramento (durata, hardware usato, metriche finali, osservazioni).
+*   **`samples/`**: Includi alcuni esempi audio diversi generati dal `best_model.pth`. Questo dimostra rapidamente l'identità vocale, la qualità e le caratteristiche del modello.
+*   **`README.md`**: Il manuale utente per questo specifico pacchetto del modello. Vedi la sezione successiva.
+
+### 9.2. Scrivere un Buon README.md del Modello
+
+Questo README è specifico per *questo pacchetto del modello*, non per la guida generale del progetto. Dovrebbe dire a chiunque (incluso il tuo futuro te stesso) tutto ciò che serve sapere per usare il modello.
+
+**Template Minimo:**
+
+```markdown
+# Pacchetto Modello TTS: Voce Maschile Yoruba v1.0
+
+## Descrizione del Modello
+- **Voce:** Voce maschile adulta e chiara che parla yoruba.
+- **Qualità dei Dati di Origine:** Addestrato su ~25 ore di registrazioni pulite di trasmissioni radiofoniche.
+- **Lingua/e:** Yoruba (principalmente). Potrebbe avere una gestione limitata dei prestiti linguistici inglesi in base ai dati di addestramento.
+- **Stile di Parlato:** Stile formale, narrativo/da trasmissione.
+- **Architettura del Modello:** [Specifica Framework/Architettura, ad esempio StyleTTS2, VITS]
+- **Versione:** 1.0
+
+## Dettagli dell'Addestramento
+- **Basato Su:** Fine-tuning da [Specifica il modello di base, ad esempio modello LibriTTS pre-addestrato] OPPURE Addestrato da zero.
+- **Dati di Addestramento:** Vedi i file inclusi `train_list.txt` e `val_list.txt`. Ore totali: ~25h.
+- **Configurazione Chiave dell'Addestramento:** Vedi il file incluso `config.yaml`.
+- **Sampling Rate:** 22050 Hz (l'audio di input deve corrispondere a questo rate per alcuni framework).
+- **Tempo di Addestramento:** Circa 48 ore su 1x NVIDIA RTX 3090.
+- **Info sul Checkpoint:** `best_model.pth` selezionato in base alla validation loss più bassa allo step [XXXXX].
+
+## Come Usarlo per l'Inferenza
+1.  **Prerequisiti:** Assicurati di avere installato il framework [Specifica il Nome del Framework TTS, ad esempio StyleTTS2], compatibile con questa versione del modello.
+2.  **Configurazione:** Usa il file incluso `config.yaml`.
+3.  **Checkpoint:** Carica il file `checkpoints/best_model.pth`.
+4.  **Testo di Input:** Fornisci input in testo semplice. La normalizzazione del testo coerente con i dati di addestramento (ad esempio l'espansione dei numeri) potrebbe migliorare i risultati.
+5.  **Speaker ID (se applicabile):** Questo è un modello a singolo speaker. Usa lo speaker ID `[Specifica l'ID usato, ad esempio main_speaker]` se richiesto dal framework, altrimenti potrebbe non essere necessario.
+6.  **Output Atteso:** L'audio sarà generato a un sampling rate di 22050 Hz.
+
+## Sample Audio
+Ascolta gli esempi generati da questo modello:
+- [Frase Breve](./samples/sample_short_sentence.wav)
+- [Domanda](./samples/sample_question.wav)
+- [Paragrafo Più Lungo](./samples/sample_longer_paragraph.wav)
+
+## Limitazioni Note / Note
+- Le prestazioni potrebbero peggiorare su testi significativamente diversi dal dominio delle trasmissioni radiofoniche.
+- Non modella esplicitamente emozioni sfumate.
+- [Aggiungi qualsiasi altra osservazione rilevante]
+
+## Licenza
+- **Pesi del Modello:** [Specifica la Licenza, ad esempio CC BY-NC-SA 4.0, Solo Uso di Ricerca/Non Commerciale, Licenza MIT - Sii accurato!]
+- **Dati di Origine:** [Indica le restrizioni di licenza dei dati di origine se influiscono sull'uso del modello, ad esempio "Addestrato su dati proprietari, modello solo per uso interno."] **Consulta la licenza dei tuoi dati di addestramento!**
+```
+
+### 9.3. Suggerimenti per il Versioning del Modello
+
+Tratta i tuoi modelli addestrati come release di software.
+
+*   **Usa il Semantic Versioning (Consigliato):** Usa nomi come `model_v1.0`, `model_v1.1`, `model_v2.0`.
+    *   Incrementa la versione PATCH (v1.0 -> v1.0.1) per piccole correzioni/riaddestramenti con gli stessi dati/config.
+    *   Incrementa la versione MINOR (v1.0 -> v1.1) per miglioramenti, riaddestramenti con più dati, modifiche significative alla config.
+    *   Incrementa la versione MAJOR (v1.0 -> v2.0) per cambiamenti architetturali importanti o riaddestramenti completi con dati/obiettivi fondamentali diversi.
+*   **Aggiorna i README:** Quando crei una nuova versione, aggiorna il suo README per riflettere i cambiamenti rispetto alla versione precedente.
+*   **Conserva le Vecchie Versioni:** Non scartare immediatamente le versioni più vecchie. A volte un modello precedente potrebbe avere prestazioni migliori su tipi specifici di testo, o potresti dover tornare indietro se una nuova versione introduce regressioni. Spazio di archiviazione permettendo, archiviale.
+
+### 9.4. Considerazioni su Condivisione e Distribuzione
+
+Se prevedi di condividere il tuo modello:
+
+*   **Packaging:** Crea un archivio compresso (ad esempio `.zip`, `.tar.gz`) dell'intera directory del pacchetto del modello (contenente checkpoint, config, README, sample, ecc.).
+*   **Piattaforme di Hosting:**
+    *   **Hugging Face Hub (Models):** Eccellente piattaforma per condividere modelli, include versioning, model card (usa il contenuto del tuo README!) e potenzialmente widget di inferenza. Facile da scoprire e usare per gli altri.
+    *   **GitHub Releases:** Adatto per modelli più piccoli, allega l'archivio zip a un tag di release nel repository del tuo progetto.
+    *   **Cloud Storage (Google Drive, Dropbox, S3):** Semplice per la condivisione diretta, ma meno individuabile e privo di funzionalità di versioning. Assicurati che i permessi dei link siano impostati correttamente.
+*   **Licensing (CRITICO):**
+    *   **Il Tuo Modello:** Scegli una licenza per i *pesi* del modello che stai distribuendo (ad esempio MIT, Apache 2.0 per quelle permissive; CC BY-NC-SA per la condivisione non commerciale).
+    *   **Dipendenza dai Dati:** **In modo cruciale, la licenza dei tuoi dati di addestramento spesso determina come puoi licenziare il tuo modello addestrato.** Se hai addestrato su dati con una licenza non commerciale, generalmente non puoi rilasciare il tuo modello sotto una licenza commerciale permissiva. Se hai addestrato su dati protetti da copyright senza autorizzazione, probabilmente non puoi condividere il modello pubblicamente affatto. **Controlla sempre le licenze delle tue fonti di dati.**
+    *   **Licenza del Framework:** Il codice del framework TTS stesso ha la propria licenza, che è separata dalla licenza del tuo modello.
+    *   **Indica Chiaramente i Termini di Utilizzo:** Usa il `README.md` all'interno del pacchetto del tuo modello per indicare chiaramente l'uso previsto (ad esempio solo ricerca, non commerciale, libero per qualsiasi uso) e i termini di licenza.
+
+---
+
+Un packaging e una documentazione appropriati dei tuoi modelli li rendono significativamente più preziosi e utilizzabili, sia per i tuoi futuri progetti che per la collaborazione e la condivisione all'interno della community.
+
+**Passo Successivo:** [Risoluzione dei Problemi e Risorse](./6_TROUBLESHOOTING_AND_RESOURCES.md){: .btn .btn-primary} | 
+[Torna in Cima](#top){: .btn .btn-primary}

--- a/languages/it/guides/6_TROUBLESHOOTING_AND_RESOURCES.md
+++ b/languages/it/guides/6_TROUBLESHOOTING_AND_RESOURCES.md
@@ -1,0 +1,86 @@
+# Guida 6: Risoluzione dei Problemi e Risorse
+
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Precedente: Packaging e Condivisione](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | 
+
+Questa guida fornisce soluzioni per i problemi comuni incontrati durante il processo di preparazione dei dati, addestramento e inferenza TTS, insieme a un elenco di strumenti e risorse utili.
+
+---
+
+## 8. Risoluzione dei Problemi Comuni
+
+Fai riferimento a questa tabella quando incontri problemi. I problemi spesso risalgono alla qualità dei dati o alle impostazioni di configurazione.
+
+| Categoria del Problema         | Problema Specifico                                      | Possibili Cause e Soluzioni                                                                                                                                                              | Guida/e Pertinente/i                                                                 |
+| :----------------------- | :-------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
+| **Preparazione dei Dati**   | Errori dello script durante chunking/normalizzazione       | Percorsi dei file errati; formato audio inizialmente non supportato; dipendenze mancanti (`ffmpeg`, `pydub`); audio estremamente rumoroso/silenzioso che confonde il rilevamento del silenzio. **Controlla i percorsi dello script, installa le dipendenze, regola i parametri del silenzio.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md)                                  |
+|                          | La generazione del manifest salta molti file                | Nomi dei file non corrispondenti tra audio e trascrizioni; file di trascrizione vuoti; percorsi errati specificati nello script; codifica non UTF-8 nei file di testo. **Verifica la denominazione, controlla i percorsi, assicurati che i file di testo abbiano contenuto e codifica UTF-8.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md)                                  |
+| **Configurazione dell'Addestramento**     | `pip install` fallisce                               | Librerie di sistema mancanti (es. `libsndfile-dev`); versione Python incompatibile; problemi di rete; conflitti tra pacchetti. **Leggi attentamente i messaggi di errore, installa le librerie di sistema, usa l'ambiente virtuale, controlla la documentazione del framework per i prerequisiti.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md)                                    |
+|                          | PyTorch `cuda is not available`                   | Versione di PyTorch errata installata (solo CPU); versione del driver NVIDIA/toolkit CUDA incompatibile; GPU non rilevata dall'OS. **Reinstalla PyTorch con la versione CUDA corretta dal sito ufficiale, aggiorna i driver.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md)                                    |
+| **Esecuzione dell'Addestramento** | Errore CUDA Out-of-Memory (OOM) all'avvio/durante l'addestramento | `batch_size` troppo grande per la VRAM della GPU; architettura del modello troppo complessa; memory leak nel framework/codice personalizzato. **Riduci `batch_size` nella config; abilita l'Automatic Mixed Precision (AMP/FP16) se disponibile; controlla gli aggiornamenti del framework.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | La Training Loss è `NaN` o diverge (esplode)     | Learning rate troppo alto; gradienti instabili; batch di dati difettoso (es. audio/testo corrotto); problemi di precisione numerica. **Abbassa il learning rate; controlla la qualità dei dati; usa il gradient clipping (spesso abilitato per impostazione predefinita); prova FP32 se usi AMP/FP16.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | La Training Loss ristagna (non diminuisce)        | Learning rate troppo basso; scarsa qualità/varietà dei dati; modello bloccato in un minimo locale; configurazione del modello errata. **Aumenta leggermente il learning rate; migliora/aumenta i dati; controlla la config (esp. parametri audio); prova un optimizer diverso.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+|                          | La Validation Loss aumenta mentre la Training Loss diminuisce (Overfitting) | Il modello memorizza i dati di addestramento; set di validazione insufficiente/non rappresentativo; addestramento troppo lungo. **Interrompi l'addestramento in anticipo (in base alla migliore val loss); aggiungi più dati di addestramento diversi; usa la regolarizzazione (weight decay, dropout - controlla la config); migliora il set di validazione.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md) |
+| **Qualità dell'Inferenza**  | L'output suona robotico/monotono                   | Addestramento insufficiente; scarsa prosodia nei dati di addestramento; limiti dell'architettura del modello; problemi di normalizzazione del testo. **Addestra più a lungo; migliora la varietà/qualità dei dati; prova un'architettura del modello diversa; assicurati che il testo sia ben punteggiato/normalizzato.** | [1_DATA_PREPARATION.md](./1_DATA_PREPARATION.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+|                          | L'output è rumoroso/confuso/incomprensibile            | Scarsa qualità dei dati (rumore incorporato); il modello non è converso; discrepanza tra config di addestramento e config/checkpoint di inferenza; sampling rate errato usato nell'inferenza. **Pulisci rigorosamente i dati di addestramento; addestra più a lungo; assicura una corrispondenza ESATTA di config/checkpoint; verifica i parametri audio.** | Tutte le Guide                                                                        |
+|                          | L'output suona come lo speaker sbagliato (fine-tuning) | Modello pre-addestrato non caricato correttamente; learning rate troppo alto inizialmente; dati/step di fine-tuning insufficienti; discrepanza dello speaker ID. **Verifica `pretrained_model_path` e `ignore_layers` nella config; usa un LR più basso per il fine-tuning; addestra più a lungo; controlla lo speaker ID.** | [2_TRAINING_SETUP.md](./2_TRAINING_SETUP.md), [3_MODEL_TRAINING.md](./3_MODEL_TRAINING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+|                          | L'inferenza si interrompe presto o parla troppo veloce/lento  | Limite del modello (predizione della durata); impostazione di inferenza che limita la lunghezza massima dell'output; parametro length scale/speed errato. **Controlla la documentazione del framework per le impostazioni dei max decoder step / max length; regola i parametri di controllo della velocità.** | [4_INFERENCE.md](./4_INFERENCE.md)                                                |
+| **Utilizzo del Modello**        | Impossibile caricare il file di checkpoint                       | Download/file corrotto; uso di un checkpoint con una versione del framework o un file di config incompatibili; percorso del file errato. **Riscarica/verifica l'integrità del file; usa la config corretta; assicurati che la versione del framework corrisponda a quella usata per l'addestramento; controlla il percorso.** | [5_PACKAGING_AND_SHARING.md](./5_PACKAGING_AND_SHARING.md), [4_INFERENCE.md](./4_INFERENCE.md) |
+
+---
+
+## 10. Risorse e Strumenti Utili
+
+Questo elenco include software, librerie e community utili per i progetti TTS.
+
+### Elaborazione e Analisi Audio:
+
+*   **[Audacity](https://www.audacityteam.org/):** Editor audio gratuito, open-source e multipiattaforma. Eccellente per l'ispezione manuale, la pulizia, l'etichettatura e l'elaborazione di base dei file audio.
+*   **[FFmpeg](https://ffmpeg.org/):** Lo strumento da riga di comando coltellino svizzero per conversione audio/video, ricampionamento, manipolazione dei canali, cambi di formato e molto altro. Essenziale per scriptare operazioni in batch.
+*   **[SoX (Sound eXchange Compiled)](http://sox.sourceforge.net/) o [Sox - Codice Sorgente](https://codeberg.org/sox_ng/sox_ng/):** Utility da riga di comando per l'elaborazione audio. Utile per effetti, conversione di formato e per ottenere informazioni audio (comando `soxi`).
+*   **[pydub](https://github.com/jiaaro/pydub):** Libreria Python per la manipolazione audio semplice (taglio, conversione di formato, regolazione del volume, rilevamento del silenzio). Usa il backend ffmpeg/libav.
+*   **[librosa](https://librosa.org/doc/latest/index.html):** Libreria Python per l'analisi audio avanzata, l'estrazione di feature (come i mel spectrogram) e la visualizzazione. Spesso usata internamente dai framework TTS.
+*   **[soundfile](https://python-soundfile.readthedocs.io/en/latest/):** Libreria Python per leggere/scrivere file audio, basata su libsndfile. Supporta molti formati.
+*   **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm):** Libreria Python per la normalizzazione della loudness (LUFS), generalmente preferita rispetto alla semplice peak normalization per una coerenza percepita.
+
+### Trascrizione (ASR):
+
+*   **[OpenAI Whisper](https://github.com/openai/whisper):** Modello ASR open-source di alta qualità, supporta molte lingue. Buona base di partenza, ma la punteggiatura spesso necessita di revisione. Può essere eseguito localmente (GPU consigliata) o tramite API. Esistono varie implementazioni della community.
+*   **[Google Gemini Models (tramite API/AI Studio)](https://ai.google.dev/):** Modelli capaci per la trascrizione, spesso danno buoni risultati su audio chiaro, potenzialmente migliori su segmenti pre-suddivisi. Controlla API/Studio per le capacità attuali e i prezzi/piani gratuiti.
+*   **Servizi Cloud ASR:**
+    *   [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text)
+    *   [AWS Transcribe](https://aws.amazon.com/transcribe/)
+    *   [Azure Speech Service](https://azure.microsoft.com/en-us/products/cognitive-services/speech-to-text/)
+    *   *Spesso affidabili, pay-as-you-go, possono avere quote gratuite iniziali.*
+*   **[Hugging Face Transformers - Modelli ASR](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition):** Hub per molti modelli ASR pre-addestrati, incluse versioni di Whisper e altri su cui è stato effettuato il fine-tuning. Esplora i modelli su cui è stato effettuato il fine-tuning per lingue specifiche o per il miglioramento della punteggiatura.
+*   **[ElevenLabs Speech To Text (Scribe)](https://elevenlabs.io/speech-to-text):** *Servizio Commerciale.* Noto per l'altissima accuratezza sia nella trascrizione che nella punteggiatura, ma è un servizio a pagamento e può essere relativamente costoso rispetto ad altri. Vale la pena considerarlo se il budget lo consente ed è richiesta la massima accuratezza pronta all'uso.
+
+### Framework e Codebase TTS (Esempi - Cerca fork/successori attivi):
+
+*   **[StyleTTS2 (Research Repo)](https://github.com/yl4579/StyleTTS2):** Lavoro influente sul controllo dello stile. Cerca fork mantenuti attivamente che abbiano implementato pipeline di addestramento/inferenza.
+*   **[VITS (Research Repo)](https://github.com/jaywalnut310/vits):** Architettura end-to-end popolare. Esistono molti fork e implementazioni.
+*   **[Coqui TTS (Archiviato)](https://github.com/coqui-ai/TTS):** Era una libreria molto popolare e completa. Sebbene archiviata, la sua codebase e i suoi concetti rimangono influenti. Potrebbero esistere molti fork attivi.
+*   **[ESPnet](https://github.com/espnet/espnet):** Toolkit end-to-end per l'elaborazione del parlato, incluse ricette TTS per vari modelli. Più orientato alla ricerca.
+*   **Cerca su GitHub:** Usa parole chiave come "TTS", "VITS training", "StyleTTS2 training", "PyTorch TTS" per trovare progetti attuali.
+
+### Ambiente Python e Deep Learning:
+
+*   **[Python](https://www.python.org/):** Il linguaggio di programmazione di base.
+*   **[PyTorch](https://pytorch.org/):** La principale libreria di deep learning usata dalla maggior parte dei framework TTS moderni.
+*   **[TensorBoard](https://www.tensorflow.org/tensorboard):** Essenziale per visualizzare i progressi dell'addestramento (funziona anche con PyTorch).
+*   **[pip](https://pip.pypa.io/en/stable/) / [uv](https://github.com/astral-sh/uv):** Installer di pacchetti Python. `uv` è un'alternativa più recente, spesso molto più veloce.
+*   **[conda](https://docs.conda.io/en/latest/) / [venv](https://docs.python.org/3/library/venv.html):** Strumenti per creare ambienti Python isolati.
+*   **[Git](https://git-scm.com/):** Sistema di controllo versione, essenziale per clonare repository e gestire il codice.
+*   **[Hugging Face Hub](https://huggingface.co/):** Piattaforma per condividere modelli (incluso TTS), dataset e codice.
+
+### Community:
+
+*   **GitHub Discussions/Issues del Framework TTS:** Controlla lo specifico repository che stai usando per domande e risposte della community.
+*   **Server Discord:** Molte community AI/ML (come LAION, EleutherAI, server di framework specifici) hanno canali dedicati al TTS.
+*   **Reddit:** Subreddit come r/SpeechSynthesis, r/MachineLearning.
+
+---
+
+Questo conclude la serie principale di guide. Ricorda che costruire buoni modelli TTS spesso comporta iterazione: rivedere la preparazione dei dati o regolare i parametri di addestramento in base ai risultati è una pratica comune. Buona fortuna!
+
+---
+**Navigazione:** [README Principale]({{ site.baseurl }}/languages/it/){: .btn .btn-primary} | [Passo Precedente: Packaging e Condivisione](./5_PACKAGING_AND_SHARING.md){: .btn .btn-primary} | [Torna in Cima](#top){: .btn .btn-primary}


### PR DESCRIPTION
This PR adds complete translations of the guide (README + all six guide files) in three languages:

- **Italian** — `languages/it/`
- **French** — `languages/fr/`
- **Spanish** — `languages/es/`

Each translation follows the repository's translation conventions:

- Same file structure and Markdown formatting as the English source (headings, tables, lists, Jekyll attributes).
- Code examples left functionally unchanged; only comments and explanatory prose are translated.
- Navigation links updated to point within each language directory (`{{ site.baseurl }}/languages/<code>/`, relative prev/next links, anchors preserved).
- Glossary terms kept in English with translated definitions.

The root `README.md` "Available Languages" section is updated to link the now-available Spanish and French versions and to add Italian to the list.
