### PR TITLE
Improve the documentation 404 page

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -3,7 +3,7 @@
 The page you requested seems to have wandered off between dataset preparation and inference. We checked the usual folders, but there is no usable signal here.
 
 !!! tip "Try a known route"
-    Start from the [home page](index.md), or jump directly to [Guide 1: Data Preparation](guides/1-data-preparation.md).
+    Start from the [home page](https://actepukc.github.io/Universal-TTS-Guide/), or jump directly to [Guide 1: Data Preparation](https://actepukc.github.io/Universal-TTS-Guide/guides/1-data-preparation/).
 
 ## Choose your language
 

--- a/docs/404.md
+++ b/docs/404.md
@@ -7,11 +7,11 @@ The page you requested seems to have wandered off between dataset preparation an
 
 ## Choose your language
 
-- [English](index.md)
-- [Български](bg/index.md)
-- [Español](es/index.md)
-- [Français](fr/index.md)
-- [Italiano](it/index.md)
+- [English](https://actepukc.github.io/Universal-TTS-Guide/)
+- [Български](https://actepukc.github.io/Universal-TTS-Guide/bg/)
+- [Español](https://actepukc.github.io/Universal-TTS-Guide/es/)
+- [Français](https://actepukc.github.io/Universal-TTS-Guide/fr/)
+- [Italiano](https://actepukc.github.io/Universal-TTS-Guide/it/)
 
 If you followed an older link, the page may have moved during the Jekyll-to-MkDocs restructuring. The guide’s navigation panel should point you to the current location.
 

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,14 +1,18 @@
-# Page Not Found
+# 404 — Voice Not Found
 
-The page you tried to open does not exist in the MkDocs version of the guide.
+The page you requested seems to have wandered off between dataset preparation and inference. We checked the usual folders, but there is no usable signal here.
 
-Useful places to continue:
+!!! tip "Try a known route"
+    Start from the [home page](index.md), or jump directly to [Guide 1: Data Preparation](guides/1-data-preparation.md).
 
-- [Home](index.md)
-- [English Guides](guides/1-data-preparation.md)
-- [Bulgarian](bg/index.md)
+## Choose your language
+
+- [English](index.md)
+- [Български](bg/index.md)
 - [Español](es/index.md)
 - [Français](fr/index.md)
 - [Italiano](it/index.md)
 
-If you followed an older link, the page may have moved during the documentation restructuring.
+If you followed an older link, the page may have moved during the Jekyll-to-MkDocs restructuring. The guide’s navigation panel should point you to the current location.
+
+_No model was harmed while searching for this page._


### PR DESCRIPTION
Improves the 404 page with a guide-themed message, direct recovery links, language shortcuts, and a brief migration note. Validated with mkdocs build --strict --clean.